### PR TITLE
[R4R]: Migrate some methods from universal to implements

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
@@ -5,6 +5,10 @@ import { Predeploys } from "../libraries/Predeploys.sol";
 import { OptimismPortal } from "./OptimismPortal.sol";
 import { CrossDomainMessenger } from "../universal/CrossDomainMessenger.sol";
 import { Semver } from "../universal/Semver.sol";
+import { SafeCall } from "../libraries/SafeCall.sol";
+import { Hashing } from "../libraries/Hashing.sol";
+import { Encoding } from "../libraries/Encoding.sol";
+import { Constants } from "../libraries/Constants.sol";
 
 /**
  * @custom:proxied
@@ -49,6 +53,162 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, Semver {
         bytes memory _data
     ) internal override {
         PORTAL.depositTransaction{ value: _value }(_to, _value, _gasLimit, false, _data);
+    }
+
+    function sendMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit
+    ) external payable override {
+        // Triggers a message to the other messenger. Note that the amount of gas provided to the
+        // message is the amount of gas requested by the user PLUS the base gas value. We want to
+        // guarantee the property that the call to the target contract will always have at least
+        // the minimum gas limit specified by the user.
+        _sendMessage(
+            OTHER_MESSENGER,
+            baseGas(_message, _minGasLimit),
+            msg.value,
+            abi.encodeWithSelector(
+                this.relayMessage.selector,
+                messageNonce(),
+                msg.sender,
+                _target,
+                msg.value,
+                _minGasLimit,
+                _message
+            )
+        );
+
+        emit SentMessage(_target, msg.sender, _message, messageNonce(), _minGasLimit);
+        emit SentMessageExtension1(msg.sender, msg.value);
+
+        unchecked {
+            ++msgNonce;
+        }
+    }
+
+    /**
+     * @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
+     *         be executed via cross-chain call from the other messenger OR if the message was
+     *         already received once and is currently being replayed.
+     *
+     * @param _nonce       Nonce of the message being relayed.
+     * @param _sender      Address of the user who sent the message.
+     * @param _target      Address that the message is targeted at.
+     * @param _value       ETH value to send with the message.
+     * @param _minGasLimit Minimum amount of gas that the message can be executed with.
+     * @param _message     Message to send to the target.
+     */
+    function relayMessage(
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _minGasLimit,
+        bytes calldata _message
+    ) external payable override {
+        (, uint16 version) = Encoding.decodeVersionedNonce(_nonce);
+        require(
+            version < 2,
+            "CrossDomainMessenger: only version 0 or 1 messages are supported at this time"
+        );
+
+        // If the message is version 0, then it's a migrated legacy withdrawal. We therefore need
+        // to check that the legacy version of the message has not already been relayed.
+        if (version == 0) {
+            bytes32 oldHash = Hashing.hashCrossDomainMessageV0(_target, _sender, _message, _nonce);
+            require(
+                successfulMessages[oldHash] == false,
+                "CrossDomainMessenger: legacy withdrawal already relayed"
+            );
+        }
+
+        // We use the v1 message hash as the unique identifier for the message because it commits
+        // to the value and minimum gas limit of the message.
+        bytes32 versionedHash = Hashing.hashCrossDomainMessageV1(
+            _nonce,
+            _sender,
+            _target,
+            _value,
+            _minGasLimit,
+            _message
+        );
+
+        if (_isOtherMessenger()) {
+            // These properties should always hold when the message is first submitted (as
+            // opposed to being replayed).
+            assert(msg.value == _value);
+            assert(!failedMessages[versionedHash]);
+        } else {
+            require(
+                msg.value == 0,
+                "CrossDomainMessenger: value must be zero unless message is from a system address"
+            );
+
+            require(
+                failedMessages[versionedHash],
+                "CrossDomainMessenger: message cannot be replayed"
+            );
+        }
+
+        require(
+            _isUnsafeTarget(_target) == false,
+            "CrossDomainMessenger: cannot send message to blocked system address"
+        );
+
+        require(
+            successfulMessages[versionedHash] == false,
+            "CrossDomainMessenger: message has already been relayed"
+        );
+
+        // If there is not enough gas left to perform the external call and finish the execution,
+        // return early and assign the message to the failedMessages mapping.
+        // We are asserting that we have enough gas to:
+        // 1. Call the target contract (_minGasLimit + RELAY_CALL_OVERHEAD + RELAY_GAS_CHECK_BUFFER)
+        //   1.a. The RELAY_CALL_OVERHEAD is included in `hasMinGas`.
+        // 2. Finish the execution after the external call (RELAY_RESERVED_GAS).
+        //
+        // If `xDomainMsgSender` is not the default L2 sender, this function
+        // is being re-entered. This marks the message as failed to allow it to be replayed.
+        if (
+            !SafeCall.hasMinGas(_minGasLimit, RELAY_RESERVED_GAS + RELAY_GAS_CHECK_BUFFER) ||
+        xDomainMsgSender != Constants.DEFAULT_L2_SENDER
+        ) {
+            failedMessages[versionedHash] = true;
+            emit FailedRelayedMessage(versionedHash);
+
+            // Revert in this case if the transaction was triggered by the estimation address. This
+            // should only be possible during gas estimation or we have bigger problems. Reverting
+            // here will make the behavior of gas estimation change such that the gas limit
+            // computed will be the amount required to relay the message, even if that amount is
+            // greater than the minimum gas limit specified by the user.
+            if (tx.origin == Constants.ESTIMATION_ADDRESS) {
+                revert("CrossDomainMessenger: failed to relay message");
+            }
+
+            return;
+        }
+
+        xDomainMsgSender = _sender;
+        bool success = SafeCall.call(_target, gasleft() - RELAY_RESERVED_GAS, _value, _message);
+        xDomainMsgSender = Constants.DEFAULT_L2_SENDER;
+
+        if (success) {
+            successfulMessages[versionedHash] = true;
+            emit RelayedMessage(versionedHash);
+        } else {
+            failedMessages[versionedHash] = true;
+            emit FailedRelayedMessage(versionedHash);
+
+            // Revert in this case if the transaction was triggered by the estimation address. This
+            // should only be possible during gas estimation or we have bigger problems. Reverting
+            // here will make the behavior of gas estimation change such that the gas limit
+            // computed will be the amount required to relay the message, even if that amount is
+            // greater than the minimum gas limit specified by the user.
+            if (tx.origin == Constants.ESTIMATION_ADDRESS) {
+                revert("CrossDomainMessenger: failed to relay message");
+            }
+        }
     }
 
     /**

--- a/packages/contracts-bedrock/contracts/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1StandardBridge.sol
@@ -4,6 +4,10 @@ pragma solidity 0.8.15;
 import { Predeploys } from "../libraries/Predeploys.sol";
 import { StandardBridge } from "../universal/StandardBridge.sol";
 import { Semver } from "../universal/Semver.sol";
+import { SafeCall } from "../libraries/SafeCall.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { OptimismMintableERC20 } from "../universal/OptimismMintableERC20.sol";
 
 /**
  * @custom:proxied
@@ -18,6 +22,7 @@ import { Semver } from "../universal/Semver.sol";
  *         not limited to: tokens with transfer fees, rebasing tokens, and tokens with blocklists.
  */
 contract L1StandardBridge is StandardBridge, Semver {
+    using SafeERC20 for IERC20;
     /**
      * @custom:legacy
      * @notice Emitted whenever a deposit of ETH from L1 into L2 is initiated.
@@ -360,5 +365,173 @@ contract L1StandardBridge is StandardBridge, Semver {
     ) internal override {
         emit ERC20WithdrawalFinalized(_localToken, _remoteToken, _from, _to, _amount, _extraData);
         super._emitERC20BridgeFinalized(_localToken, _remoteToken, _from, _to, _amount, _extraData);
+    }
+
+    /**
+     * @notice Sends ETH to the sender's address on the other chain.
+     *
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeETH(uint32 _minGasLimit, bytes calldata _extraData) public payable onlyEOA override {
+        _initiateBridgeETH(msg.sender, msg.sender, msg.value, _minGasLimit, _extraData);
+    }
+
+    /**
+     * @notice Sends ETH to a receiver's address on the other chain. Note that if ETH is sent to a
+     *         smart contract and the call fails, the ETH will be temporarily locked in the
+     *         StandardBridge on the other chain until the call is replayed. If the call cannot be
+     *         replayed with any amount of gas (call always reverts), then the ETH will be
+     *         permanently locked in the StandardBridge on the other chain. ETH will also
+     *         be locked if the receiver is the other bridge, because finalizeBridgeETH will revert
+     *         in that case.
+     *
+     * @param _to          Address of the receiver.
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeETHTo(
+        address _to,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public payable override {
+        _initiateBridgeETH(msg.sender, _to, msg.value, _minGasLimit, _extraData);
+    }
+
+    /**
+     * @notice Sends ERC20 tokens to the sender's address on the other chain. Note that if the
+     *         ERC20 token on the other chain does not recognize the local token as the correct
+     *         pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+     *         this chain.
+     *
+     * @param _localToken  Address of the ERC20 on this chain.
+     * @param _remoteToken Address of the corresponding token on the remote chain.
+     * @param _amount      Amount of local tokens to deposit.
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeERC20(
+        address _localToken,
+        address _remoteToken,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public onlyEOA override {
+        _initiateBridgeERC20(
+            _localToken,
+            _remoteToken,
+            msg.sender,
+            msg.sender,
+            _amount,
+            _minGasLimit,
+            _extraData
+        );
+    }
+
+    /**
+     * @notice Sends ERC20 tokens to a receiver's address on the other chain. Note that if the
+     *         ERC20 token on the other chain does not recognize the local token as the correct
+     *         pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+     *         this chain.
+     *
+     * @param _localToken  Address of the ERC20 on this chain.
+     * @param _remoteToken Address of the corresponding token on the remote chain.
+     * @param _to          Address of the receiver.
+     * @param _amount      Amount of local tokens to deposit.
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeERC20To(
+        address _localToken,
+        address _remoteToken,
+        address _to,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public override {
+        _initiateBridgeERC20(
+            _localToken,
+            _remoteToken,
+            msg.sender,
+            _to,
+            _amount,
+            _minGasLimit,
+            _extraData
+        );
+    }
+
+    /**
+     * @notice Finalizes an ETH bridge on this chain. Can only be triggered by the other
+     *         StandardBridge contract on the remote chain.
+     *
+     * @param _from      Address of the sender.
+     * @param _to        Address of the receiver.
+     * @param _amount    Amount of ETH being bridged.
+     * @param _extraData Extra data to be sent with the transaction. Note that the recipient will
+     *                   not be triggered with this data, but it will be emitted and can be used
+     *                   to identify the transaction.
+     */
+    function finalizeBridgeETH(
+        address _from,
+        address _to,
+        uint256 _amount,
+        bytes calldata _extraData
+    ) public payable onlyOtherBridge override {
+        require(msg.value == _amount, "StandardBridge: amount sent does not match amount required");
+        require(_to != address(this), "StandardBridge: cannot send to self");
+        require(_to != address(MESSENGER), "StandardBridge: cannot send to messenger");
+
+        // Emit the correct events. By default this will be _amount, but child
+        // contracts may override this function in order to emit legacy events as well.
+        _emitETHBridgeFinalized(_from, _to, _amount, _extraData);
+
+        bool success = SafeCall.call(_to, gasleft(), _amount, hex"");
+        require(success, "StandardBridge: ETH transfer failed");
+    }
+
+    /**
+     * @notice Finalizes an ERC20 bridge on this chain. Can only be triggered by the other
+     *         StandardBridge contract on the remote chain.
+     *
+     * @param _localToken  Address of the ERC20 on this chain.
+     * @param _remoteToken Address of the corresponding token on the remote chain.
+     * @param _from        Address of the sender.
+     * @param _to          Address of the receiver.
+     * @param _amount      Amount of the ERC20 being bridged.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function finalizeBridgeERC20(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _amount,
+        bytes calldata _extraData
+    ) public onlyOtherBridge override {
+        if (_isOptimismMintableERC20(_localToken)) {
+            require(
+                _isCorrectTokenPair(_localToken, _remoteToken),
+                "StandardBridge: wrong remote token for Optimism Mintable ERC20 local token"
+            );
+
+            OptimismMintableERC20(_localToken).mint(_to, _amount);
+        } else {
+            deposits[_localToken][_remoteToken] = deposits[_localToken][_remoteToken] - _amount;
+            IERC20(_localToken).safeTransfer(_to, _amount);
+        }
+
+        // Emit the correct events. By default this will be ERC20BridgeFinalized, but child
+        // contracts may override this function in order to emit legacy events as well.
+        _emitERC20BridgeFinalized(_localToken, _remoteToken, _from, _to, _amount, _extraData);
     }
 }

--- a/packages/contracts-bedrock/contracts/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2CrossDomainMessenger.sol
@@ -6,6 +6,10 @@ import { Predeploys } from "../libraries/Predeploys.sol";
 import { CrossDomainMessenger } from "../universal/CrossDomainMessenger.sol";
 import { Semver } from "../universal/Semver.sol";
 import { L2ToL1MessagePasser } from "./L2ToL1MessagePasser.sol";
+import { SafeCall } from "../libraries/SafeCall.sol";
+import { Hashing } from "../libraries/Hashing.sol";
+import { Encoding } from "../libraries/Encoding.sol";
+import { Constants } from "../libraries/Constants.sol";
 
 /**
  * @custom:proxied
@@ -57,6 +61,162 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, Semver {
         L2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal{
             value: _value
         }(_to, _gasLimit, _data);
+    }
+
+    function sendMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit
+    ) external payable override {
+        // Triggers a message to the other messenger. Note that the amount of gas provided to the
+        // message is the amount of gas requested by the user PLUS the base gas value. We want to
+        // guarantee the property that the call to the target contract will always have at least
+        // the minimum gas limit specified by the user.
+        _sendMessage(
+            OTHER_MESSENGER,
+            baseGas(_message, _minGasLimit),
+            msg.value,
+            abi.encodeWithSelector(
+                this.relayMessage.selector,
+                messageNonce(),
+                msg.sender,
+                _target,
+                msg.value,
+                _minGasLimit,
+                _message
+            )
+        );
+
+        emit SentMessage(_target, msg.sender, _message, messageNonce(), _minGasLimit);
+        emit SentMessageExtension1(msg.sender, msg.value);
+
+        unchecked {
+            ++msgNonce;
+        }
+    }
+
+    /**
+     * @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
+     *         be executed via cross-chain call from the other messenger OR if the message was
+     *         already received once and is currently being replayed.
+     *
+     * @param _nonce       Nonce of the message being relayed.
+     * @param _sender      Address of the user who sent the message.
+     * @param _target      Address that the message is targeted at.
+     * @param _value       ETH value to send with the message.
+     * @param _minGasLimit Minimum amount of gas that the message can be executed with.
+     * @param _message     Message to send to the target.
+     */
+    function relayMessage(
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _minGasLimit,
+        bytes calldata _message
+    ) external payable override {
+        (, uint16 version) = Encoding.decodeVersionedNonce(_nonce);
+        require(
+            version < 2,
+            "CrossDomainMessenger: only version 0 or 1 messages are supported at this time"
+        );
+
+        // If the message is version 0, then it's a migrated legacy withdrawal. We therefore need
+        // to check that the legacy version of the message has not already been relayed.
+        if (version == 0) {
+            bytes32 oldHash = Hashing.hashCrossDomainMessageV0(_target, _sender, _message, _nonce);
+            require(
+                successfulMessages[oldHash] == false,
+                "CrossDomainMessenger: legacy withdrawal already relayed"
+            );
+        }
+
+        // We use the v1 message hash as the unique identifier for the message because it commits
+        // to the value and minimum gas limit of the message.
+        bytes32 versionedHash = Hashing.hashCrossDomainMessageV1(
+            _nonce,
+            _sender,
+            _target,
+            _value,
+            _minGasLimit,
+            _message
+        );
+
+        if (_isOtherMessenger()) {
+            // These properties should always hold when the message is first submitted (as
+            // opposed to being replayed).
+            assert(msg.value == _value);
+            assert(!failedMessages[versionedHash]);
+        } else {
+            require(
+                msg.value == 0,
+                "CrossDomainMessenger: value must be zero unless message is from a system address"
+            );
+
+            require(
+                failedMessages[versionedHash],
+                "CrossDomainMessenger: message cannot be replayed"
+            );
+        }
+
+        require(
+            _isUnsafeTarget(_target) == false,
+            "CrossDomainMessenger: cannot send message to blocked system address"
+        );
+
+        require(
+            successfulMessages[versionedHash] == false,
+            "CrossDomainMessenger: message has already been relayed"
+        );
+
+        // If there is not enough gas left to perform the external call and finish the execution,
+        // return early and assign the message to the failedMessages mapping.
+        // We are asserting that we have enough gas to:
+        // 1. Call the target contract (_minGasLimit + RELAY_CALL_OVERHEAD + RELAY_GAS_CHECK_BUFFER)
+        //   1.a. The RELAY_CALL_OVERHEAD is included in `hasMinGas`.
+        // 2. Finish the execution after the external call (RELAY_RESERVED_GAS).
+        //
+        // If `xDomainMsgSender` is not the default L2 sender, this function
+        // is being re-entered. This marks the message as failed to allow it to be replayed.
+        if (
+            !SafeCall.hasMinGas(_minGasLimit, RELAY_RESERVED_GAS + RELAY_GAS_CHECK_BUFFER) ||
+        xDomainMsgSender != Constants.DEFAULT_L2_SENDER
+        ) {
+            failedMessages[versionedHash] = true;
+            emit FailedRelayedMessage(versionedHash);
+
+            // Revert in this case if the transaction was triggered by the estimation address. This
+            // should only be possible during gas estimation or we have bigger problems. Reverting
+            // here will make the behavior of gas estimation change such that the gas limit
+            // computed will be the amount required to relay the message, even if that amount is
+            // greater than the minimum gas limit specified by the user.
+            if (tx.origin == Constants.ESTIMATION_ADDRESS) {
+                revert("CrossDomainMessenger: failed to relay message");
+            }
+
+            return;
+        }
+
+        xDomainMsgSender = _sender;
+        bool success = SafeCall.call(_target, gasleft() - RELAY_RESERVED_GAS, _value, _message);
+        xDomainMsgSender = Constants.DEFAULT_L2_SENDER;
+
+        if (success) {
+            successfulMessages[versionedHash] = true;
+            emit RelayedMessage(versionedHash);
+        } else {
+            failedMessages[versionedHash] = true;
+            emit FailedRelayedMessage(versionedHash);
+
+            // Revert in this case if the transaction was triggered by the estimation address. This
+            // should only be possible during gas estimation or we have bigger problems. Reverting
+            // here will make the behavior of gas estimation change such that the gas limit
+            // computed will be the amount required to relay the message, even if that amount is
+            // greater than the minimum gas limit specified by the user.
+            if (tx.origin == Constants.ESTIMATION_ADDRESS) {
+                revert("CrossDomainMessenger: failed to relay message");
+            }
+        }
     }
 
     /**

--- a/packages/contracts-bedrock/contracts/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2StandardBridge.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.15;
 import { Predeploys } from "../libraries/Predeploys.sol";
 import { StandardBridge } from "../universal/StandardBridge.sol";
 import { Semver } from "../universal/Semver.sol";
+import { SafeCall } from "../libraries/SafeCall.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { OptimismMintableERC20 } from "../universal/OptimismMintableERC20.sol";
 
 /**
@@ -18,6 +21,7 @@ import { OptimismMintableERC20 } from "../universal/OptimismMintableERC20.sol";
  *         not limited to: tokens with transfer fees, rebasing tokens, and tokens with blocklists.
  */
 contract L2StandardBridge is StandardBridge, Semver {
+    using SafeERC20 for IERC20;
     /**
      * @custom:legacy
      * @notice Emitted whenever a withdrawal from L2 to L1 is initiated.
@@ -98,7 +102,7 @@ contract L2StandardBridge is StandardBridge, Semver {
         uint256 _amount,
         uint32 _minGasLimit,
         bytes calldata _extraData
-    ) external payable virtual onlyEOA {
+    ) external payable onlyEOA {
         _initiateWithdrawal(_l2Token, msg.sender, msg.sender, _amount, _minGasLimit, _extraData);
     }
 
@@ -124,7 +128,7 @@ contract L2StandardBridge is StandardBridge, Semver {
         uint256 _amount,
         uint32 _minGasLimit,
         bytes calldata _extraData
-    ) external payable virtual {
+    ) external payable {
         _initiateWithdrawal(_l2Token, msg.sender, _to, _amount, _minGasLimit, _extraData);
     }
 
@@ -147,7 +151,7 @@ contract L2StandardBridge is StandardBridge, Semver {
         address _to,
         uint256 _amount,
         bytes calldata _extraData
-    ) external payable virtual {
+    ) external payable {
         if (_l1Token == address(0) && _l2Token == Predeploys.LEGACY_ERC20_ETH) {
             finalizeBridgeETH(_from, _to, _amount, _extraData);
         } else {
@@ -272,5 +276,173 @@ contract L2StandardBridge is StandardBridge, Semver {
     ) internal override {
         emit DepositFinalized(_remoteToken, _localToken, _from, _to, _amount, _extraData);
         super._emitERC20BridgeFinalized(_localToken, _remoteToken, _from, _to, _amount, _extraData);
+    }
+
+    /**
+     * @notice Sends ETH to the sender's address on the other chain.
+     *
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeETH(uint32 _minGasLimit, bytes calldata _extraData) public payable override onlyEOA {
+        _initiateBridgeETH(msg.sender, msg.sender, msg.value, _minGasLimit, _extraData);
+    }
+
+    /**
+     * @notice Sends ETH to a receiver's address on the other chain. Note that if ETH is sent to a
+     *         smart contract and the call fails, the ETH will be temporarily locked in the
+     *         StandardBridge on the other chain until the call is replayed. If the call cannot be
+     *         replayed with any amount of gas (call always reverts), then the ETH will be
+     *         permanently locked in the StandardBridge on the other chain. ETH will also
+     *         be locked if the receiver is the other bridge, because finalizeBridgeETH will revert
+     *         in that case.
+     *
+     * @param _to          Address of the receiver.
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeETHTo(
+        address _to,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public payable override {
+        _initiateBridgeETH(msg.sender, _to, msg.value, _minGasLimit, _extraData);
+    }
+
+    /**
+     * @notice Sends ERC20 tokens to the sender's address on the other chain. Note that if the
+     *         ERC20 token on the other chain does not recognize the local token as the correct
+     *         pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+     *         this chain.
+     *
+     * @param _localToken  Address of the ERC20 on this chain.
+     * @param _remoteToken Address of the corresponding token on the remote chain.
+     * @param _amount      Amount of local tokens to deposit.
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeERC20(
+        address _localToken,
+        address _remoteToken,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public onlyEOA override {
+        _initiateBridgeERC20(
+            _localToken,
+            _remoteToken,
+            msg.sender,
+            msg.sender,
+            _amount,
+            _minGasLimit,
+            _extraData
+        );
+    }
+
+    /**
+     * @notice Sends ERC20 tokens to a receiver's address on the other chain. Note that if the
+     *         ERC20 token on the other chain does not recognize the local token as the correct
+     *         pair token, the ERC20 bridge will fail and the tokens will be returned to sender on
+     *         this chain.
+     *
+     * @param _localToken  Address of the ERC20 on this chain.
+     * @param _remoteToken Address of the corresponding token on the remote chain.
+     * @param _to          Address of the receiver.
+     * @param _amount      Amount of local tokens to deposit.
+     * @param _minGasLimit Minimum amount of gas that the bridge can be relayed with.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function bridgeERC20To(
+        address _localToken,
+        address _remoteToken,
+        address _to,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public override {
+        _initiateBridgeERC20(
+            _localToken,
+            _remoteToken,
+            msg.sender,
+            _to,
+            _amount,
+            _minGasLimit,
+            _extraData
+        );
+    }
+
+    /**
+     * @notice Finalizes an ETH bridge on this chain. Can only be triggered by the other
+     *         StandardBridge contract on the remote chain.
+     *
+     * @param _from      Address of the sender.
+     * @param _to        Address of the receiver.
+     * @param _amount    Amount of ETH being bridged.
+     * @param _extraData Extra data to be sent with the transaction. Note that the recipient will
+     *                   not be triggered with this data, but it will be emitted and can be used
+     *                   to identify the transaction.
+     */
+    function finalizeBridgeETH(
+        address _from,
+        address _to,
+        uint256 _amount,
+        bytes calldata _extraData
+    ) public payable onlyOtherBridge override {
+        require(msg.value == _amount, "StandardBridge: amount sent does not match amount required");
+        require(_to != address(this), "StandardBridge: cannot send to self");
+        require(_to != address(MESSENGER), "StandardBridge: cannot send to messenger");
+
+        // Emit the correct events. By default this will be _amount, but child
+        // contracts may override this function in order to emit legacy events as well.
+        _emitETHBridgeFinalized(_from, _to, _amount, _extraData);
+
+        bool success = SafeCall.call(_to, gasleft(), _amount, hex"");
+        require(success, "StandardBridge: ETH transfer failed");
+    }
+
+    /**
+     * @notice Finalizes an ERC20 bridge on this chain. Can only be triggered by the other
+     *         StandardBridge contract on the remote chain.
+     *
+     * @param _localToken  Address of the ERC20 on this chain.
+     * @param _remoteToken Address of the corresponding token on the remote chain.
+     * @param _from        Address of the sender.
+     * @param _to          Address of the receiver.
+     * @param _amount      Amount of the ERC20 being bridged.
+     * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
+     *                     not be triggered with this data, but it will be emitted and can be used
+     *                     to identify the transaction.
+     */
+    function finalizeBridgeERC20(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _amount,
+        bytes calldata _extraData
+    ) public onlyOtherBridge override {
+        if (_isOptimismMintableERC20(_localToken)) {
+            require(
+                _isCorrectTokenPair(_localToken, _remoteToken),
+                "StandardBridge: wrong remote token for Optimism Mintable ERC20 local token"
+            );
+
+            OptimismMintableERC20(_localToken).mint(_to, _amount);
+        } else {
+            deposits[_localToken][_remoteToken] = deposits[_localToken][_remoteToken] - _amount;
+            IERC20(_localToken).safeTransfer(_to, _amount);
+        }
+
+        // Emit the correct events. By default this will be ERC20BridgeFinalized, but child
+        // contracts may override this function in order to emit legacy events as well.
+        _emitERC20BridgeFinalized(_localToken, _remoteToken, _from, _to, _amount, _extraData);
     }
 }

--- a/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
@@ -260,7 +260,7 @@ abstract contract CrossDomainMessenger is
         address _target,
         bytes calldata _message,
         uint32 _minGasLimit
-    ) external payable {
+    ) external payable virtual {
         // Triggers a message to the other messenger. Note that the amount of gas provided to the
         // message is the amount of gas requested by the user PLUS the base gas value. We want to
         // guarantee the property that the call to the target contract will always have at least
@@ -307,7 +307,7 @@ abstract contract CrossDomainMessenger is
         uint256 _value,
         uint256 _minGasLimit,
         bytes calldata _message
-    ) external payable {
+    ) external payable virtual {
         (, uint16 version) = Encoding.decodeVersionedNonce(_nonce);
         require(
             version < 2,

--- a/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
@@ -187,7 +187,7 @@ abstract contract StandardBridge {
      *                     not be triggered with this data, but it will be emitted and can be used
      *                     to identify the transaction.
      */
-    function bridgeETH(uint32 _minGasLimit, bytes calldata _extraData) public payable onlyEOA {
+    function bridgeETH(uint32 _minGasLimit, bytes calldata _extraData) public payable virtual onlyEOA {
         _initiateBridgeETH(msg.sender, msg.sender, msg.value, _minGasLimit, _extraData);
     }
 
@@ -210,7 +210,7 @@ abstract contract StandardBridge {
         address _to,
         uint32 _minGasLimit,
         bytes calldata _extraData
-    ) public payable {
+    ) public payable virtual{
         _initiateBridgeETH(msg.sender, _to, msg.value, _minGasLimit, _extraData);
     }
 
@@ -296,7 +296,7 @@ abstract contract StandardBridge {
         address _to,
         uint256 _amount,
         bytes calldata _extraData
-    ) public payable onlyOtherBridge {
+    ) public payable virtual onlyOtherBridge {
         require(msg.value == _amount, "StandardBridge: amount sent does not match amount required");
         require(_to != address(this), "StandardBridge: cannot send to self");
         require(_to != address(MESSENGER), "StandardBridge: cannot send to messenger");
@@ -329,7 +329,7 @@ abstract contract StandardBridge {
         address _to,
         uint256 _amount,
         bytes calldata _extraData
-    ) public onlyOtherBridge {
+    ) public virtual onlyOtherBridge {
         if (_isOptimismMintableERC20(_localToken)) {
             require(
                 _isCorrectTokenPair(_localToken, _remoteToken),
@@ -364,7 +364,7 @@ abstract contract StandardBridge {
         uint256 _amount,
         uint32 _minGasLimit,
         bytes memory _extraData
-    ) internal {
+    ) internal virtual {
         require(
             msg.value == _amount,
             "StandardBridge: bridging ETH must include sufficient ETH value"
@@ -407,7 +407,7 @@ abstract contract StandardBridge {
         uint256 _amount,
         uint32 _minGasLimit,
         bytes memory _extraData
-    ) internal {
+    ) internal virtual {
         if (_isOptimismMintableERC20(_localToken)) {
             require(
                 _isCorrectTokenPair(_localToken, _remoteToken),


### PR DESCRIPTION
Base on original optimism contract, we just change some methods in `StandardBridge` and `CrossDomainMessage` to virtual, and override these methods in `L1StandardBridge`, `L2StandardBridge`, `L1CrossDomainMessage` and `L2CrossDomainMessage`.

In later PRs, we just need to update these override methods, thus we won't be confused about what is `msg.value` represents to. In `L1StandardBridge` and `L1CrossDomainMessage`, `msg.value` represents ETH token. In `L2StandardBridge` and `L2CrossDomainMessage`, `msg.value` represents MNT token.