### PR TITLE
[R4R]: add auto check makebuild workflow job for pr

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checking Make Build
         run: |
           unset NVM_DIR
-          apt update
-          apt install -y build-essential  coreutils libuv1 libudev-dev libusb-1.0-0-dev
+          sudo apt update
+          sudo apt install -y build-essential  coreutils libuv1 libudev-dev libusb-1.0-0-dev
           make build
 


### PR DESCRIPTION
Description:
Add a job to trigger a check for build success after creating a PR.

This does several things to check
1. use some service dependencies (node: 16, pnmp: 8.9.2, foundry: nightly, go: 1.19)
2. use command make build to check