### PR TITLE
WIP: fix struct tag and fix compile error

### DIFF
--- a/op-chain-ops/eof/eof_crawler.go
+++ b/op-chain-ops/eof/eof_crawler.go
@@ -94,7 +94,7 @@ func IndexEOFContracts(dbPath string, out string) error {
 		}
 
 		// Attempt to get the address of the account from the trie
-		addrBytes, err := st.Get(it.Key)
+		addrBytes := st.Get(it.Key)
 		if err != nil {
 			return fmt.Errorf("load address for account: %w", err)
 		}

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -27,7 +27,7 @@ type Frame struct {
 	ID          ChannelID `json:"id"`
 	FrameNumber uint16    `json:"frame_number"`
 	Data        []byte    `json:"data"`
-	IsLast      bool      `'json:"is_last"`
+	IsLast      bool      `json:"is_last"`
 }
 
 // MarshalBinary writes the frame to `w`.


### PR DESCRIPTION
Cherry pick https://github.com/ethereum-optimism/optimism/pull/6282

The wrong frame tag can cause frequent L2 reorg when the traffic on L2 is huge.