### PR TITLE
[R4R]fix Incorrect cache clearing in op-batcher

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -75,7 +75,6 @@ func (s *channelManager) Clear() {
 	s.tip = common.Hash{}
 	s.closed = false
 	s.clearPendingChannel()
-	s.clearMantleDAStatus()
 }
 
 // TxFailed records a transaction as failed. It will attempt to resubmit the data
@@ -143,6 +142,7 @@ func (s *channelManager) clearPendingChannel() {
 func (s *channelManager) clearMantleDAStatus() {
 	s.params = nil
 	s.initStoreDataReceipt = nil
+	s.daPendingTxData = make(map[txID]txData)
 	s.daUnConfirmedTxID = s.daUnConfirmedTxID[:0]
 	s.metr.RecordRollupRetry(0)
 }


### PR DESCRIPTION
The da rollup cache is not cleaned, and in the case of a retry, it will pack invalid data