### PR TITLE
[R4R]-[op-geth]feat: update op-geth library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.19
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v1.101105.4-0.20231129060035-fc472cfc4eeb
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.0
 
 replace github.com/Layr-Labs/datalayr/common v0.0.0 => ./datalayr/common
 

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mantlenetworkio/op-geth v1.101105.4-0.20231129060035-fc472cfc4eeb h1:uvaRYXUV/Bt8dcTG5tubKqhR/jCv8Wpl7NlJBCX8bgg=
-github.com/mantlenetworkio/op-geth v1.101105.4-0.20231129060035-fc472cfc4eeb/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
+github.com/mantlenetworkio/op-geth v0.5.0 h1:TAhKgFQ1mcsY0UfF6kDqpW8ba4dk2qFn4Skl2V9/esw=
+github.com/mantlenetworkio/op-geth v0.5.0/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=


### PR DESCRIPTION
Core changes:
- use [op-geth v0.5.0](https://github.com/mantlenetworkio/op-geth/releases/tag/v0.5.0) as library