### PR TITLE
[R4R]-[baseFee]feat: use block time to determine baseFee upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.19
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103113457-c6f5610fc67b
-
-//replace github.com/ethereum/go-ethereum v1.11.6 => /Users/leo/go/src/github.com/mantlenetworkio/rde-bedrock/op-geth
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103145130-9257262a08ab
 
 replace github.com/Layr-Labs/datalayr/common v0.0.0 => ./datalayr/common
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.19
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103032433-888ed6e783d3
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103083043-1b40bd5739ea
 
 replace github.com/Layr-Labs/datalayr/common v0.0.0 => ./datalayr/common
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.19
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20231228085828-7beb8e16ef02
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103032433-888ed6e783d3
 
 replace github.com/Layr-Labs/datalayr/common v0.0.0 => ./datalayr/common
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,9 @@ module github.com/ethereum-optimism/optimism
 
 go 1.19
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103083043-1b40bd5739ea
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103105726-a7b95018d053
+
+//replace github.com/ethereum/go-ethereum v1.11.6 => /Users/leo/go/src/github.com/mantlenetworkio/rde-bedrock/op-geth
 
 replace github.com/Layr-Labs/datalayr/common v0.0.0 => ./datalayr/common
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.19
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103105726-a7b95018d053
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/mantlenetworkio/op-geth v0.5.1-0.20240103113457-c6f5610fc67b
 
 //replace github.com/ethereum/go-ethereum v1.11.6 => /Users/leo/go/src/github.com/mantlenetworkio/rde-bedrock/op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103113457-c6f5610fc67b h1:6Cfj5GOs39shuqHFdXE0hlJd1rt5rA6tHdtFD6iU+bU=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103113457-c6f5610fc67b/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103145130-9257262a08ab h1:OoF84olpudRowlRtbWPCaT+lvH7BSGROqKUlzPUq3Gk=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103145130-9257262a08ab/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20231228085828-7beb8e16ef02 h1:OuctBLWL0jAMm6mHwCSfQYdiUVTF2L5newmAI2VyY0U=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20231228085828-7beb8e16ef02/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103032433-888ed6e783d3 h1:5bOt/R4+ArkKw2e5OCEaj21r8O0YRn4cSiTxmofe8c0=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103032433-888ed6e783d3/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103105726-a7b95018d053 h1:DsnbgeMYatoJ5Q3eafB321pOA3E0J3eW6QN7wxJi3XM=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103105726-a7b95018d053/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103113457-c6f5610fc67b h1:6Cfj5GOs39shuqHFdXE0hlJd1rt5rA6tHdtFD6iU+bU=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103113457-c6f5610fc67b/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103032433-888ed6e783d3 h1:5bOt/R4+ArkKw2e5OCEaj21r8O0YRn4cSiTxmofe8c0=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103032433-888ed6e783d3/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103083043-1b40bd5739ea h1:I4XW5sAMIQwOpAq8SZC84L+pYKdfg4SIJv+mmw+wedU=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103083043-1b40bd5739ea/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103083043-1b40bd5739ea h1:I4XW5sAMIQwOpAq8SZC84L+pYKdfg4SIJv+mmw+wedU=
-github.com/mantlenetworkio/op-geth v0.5.1-0.20240103083043-1b40bd5739ea/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103105726-a7b95018d053 h1:DsnbgeMYatoJ5Q3eafB321pOA3E0J3eW6QN7wxJi3XM=
+github.com/mantlenetworkio/op-geth v0.5.1-0.20240103105726-a7b95018d053/go.mod h1:SGLXBOtu2JlKrNoUG76EatI2uJX/WZRY4nmEyvE9Q38=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -109,6 +109,10 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	txs = append(txs, l1InfoTx)
 	txs = append(txs, depositTxs...)
 
+	if !ba.cfg.IsBaseFee(nextL2Time) {
+		sysConfig.BaseFee = nil
+	}
+
 	return &eth.PayloadAttributes{
 		Timestamp:             hexutil.Uint64(nextL2Time),
 		PrevRandao:            eth.Bytes32(l1Info.MixDigest()),

--- a/op-node/rollup/derive/engine_consolidate.go
+++ b/op-node/rollup/derive/engine_consolidate.go
@@ -41,11 +41,8 @@ func AttributesMatchBlock(attrs *eth.PayloadAttributes, parentHash common.Hash, 
 	if *attrs.GasLimit != block.GasLimit {
 		return fmt.Errorf("gas limit does not match. expected %d. got: %d", *attrs.GasLimit, block.GasLimit)
 	}
-	log.Info("AttributesMatchBlock", "attrs.BaseFee", attrs.BaseFee)
 	if attrs.BaseFee != nil {
-		log.Info("AttributesMatchBlock", "attrs.BaseFee", attrs.BaseFee.String(), "block.BlockNumber", block.BlockNumber, "block.BaseFee", block.BaseFeePerGas.String())
-	} else {
-		log.Info("AttributesMatchBlock", "attrs.BaseFee", attrs.BaseFee)
+		log.Info("attributes match block check", "blockNumber", block.BlockNumber, "attrs", attrs.BaseFee.String(), "block", block.BaseFeePerGas.String())
 	}
 	if attrs.BaseFee != nil && block.BaseFeePerGas.ToBig().Cmp(attrs.BaseFee) != 0 {
 		return fmt.Errorf("base fee does not match. blockNumber %d. expected %s. got: %s", block.BlockNumber, attrs.BaseFee.String(), block.BaseFeePerGas.String())

--- a/op-node/rollup/derive/engine_consolidate.go
+++ b/op-node/rollup/derive/engine_consolidate.go
@@ -41,8 +41,14 @@ func AttributesMatchBlock(attrs *eth.PayloadAttributes, parentHash common.Hash, 
 	if *attrs.GasLimit != block.GasLimit {
 		return fmt.Errorf("gas limit does not match. expected %d. got: %d", *attrs.GasLimit, block.GasLimit)
 	}
-	if block.BaseFeePerGas.ToBig().Cmp(attrs.BaseFee) != 0 {
-		return fmt.Errorf("base fee does not match. expected %s. got: %s", attrs.BaseFee.String(), block.BaseFeePerGas.String())
+	log.Info("AttributesMatchBlock", "attrs.BaseFee", attrs.BaseFee)
+	if attrs.BaseFee != nil {
+		log.Info("AttributesMatchBlock", "attrs.BaseFee", attrs.BaseFee.String(), "block.BlockNumber", block.BlockNumber, "block.BaseFee", block.BaseFeePerGas.String())
+	} else {
+		log.Info("AttributesMatchBlock", "attrs.BaseFee", attrs.BaseFee)
+	}
+	if attrs.BaseFee != nil && block.BaseFeePerGas.ToBig().Cmp(attrs.BaseFee) != 0 {
+		return fmt.Errorf("base fee does not match. blockNumber %d. expected %s. got: %s", block.BlockNumber, attrs.BaseFee.String(), block.BaseFeePerGas.String())
 	}
 	return nil
 }

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -76,6 +76,10 @@ type Config struct {
 	// Active if RegolithTime != nil && L2 block timestamp >= *RegolithTime, inactive otherwise.
 	RegolithTime *uint64 `json:"regolith_time,omitempty"`
 
+	// BaseFeeTime sets the activation time of the BaseFee network-upgrade:
+	// Active if BaseFeeTime != nil && L2 block timestamp >= *BaseFeeTime, inactive otherwise.
+	BaseFeeTime *uint64 `json:"base_fee_time,omitempty"`
+
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
 
@@ -263,6 +267,11 @@ func (c *Config) L1Signer() types.Signer {
 // IsRegolith returns true if the Regolith hardfork is active at or past the given timestamp.
 func (c *Config) IsRegolith(timestamp uint64) bool {
 	return c.RegolithTime != nil && timestamp >= *c.RegolithTime
+}
+
+// IsBaseFee returns true if the BaseFee hardfork is active at or past the given timestamp.
+func (c *Config) IsBaseFee(timestamp uint64) bool {
+	return c.BaseFeeTime != nil && timestamp >= *c.BaseFeeTime
 }
 
 // Description outputs a banner describing the important parts of rollup configuration in a human-readable form.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -186,6 +186,9 @@ func NewRollupConfig(ctx *cli.Context) (*rollup.Config, error) {
 	if err := json.NewDecoder(file).Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
+
+	initMantleUpgradeConfig(&rollupConfig)
+
 	return &rollupConfig, nil
 }
 

--- a/op-node/service_mantle.go
+++ b/op-node/service_mantle.go
@@ -2,16 +2,15 @@ package opnode
 
 import (
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 func initMantleUpgradeConfig(rollupConfig *rollup.Config) {
-	switch rollupConfig.L2ChainID {
-	case params.MantleSepoliaChainId:
-		rollupConfig.BaseFeeTime = core.MantleSepoliaUpgradeConfig.BaseFeeTime
-	default:
+	upgradeConfig := core.GetUpgradeConfigForMantle(rollupConfig.L2ChainID)
+	if upgradeConfig == nil {
 		rollupConfig.BaseFeeTime = nil
+		return
 	}
+	rollupConfig.BaseFeeTime = upgradeConfig.BaseFeeTime
 }

--- a/op-node/service_mantle.go
+++ b/op-node/service_mantle.go
@@ -1,0 +1,17 @@
+package opnode
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+)
+
+func initMantleUpgradeConfig(rollupConfig *rollup.Config) {
+	switch rollupConfig.L2ChainID {
+	case params.MantleSepoliaChainId:
+		rollupConfig.BaseFeeTime = core.MantleSepoliaUpgradeConfig.BaseFeeTime
+	default:
+		rollupConfig.BaseFeeTime = nil
+	}
+}


### PR DESCRIPTION
Core changes:
- use `block timestamp` as `BaseFee` upgrade flag

Releated PR:
- https://github.com/mantlenetworkio/op-geth/pull/27