### PR TITLE
compatible with custom bridge

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
@@ -106,6 +106,43 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, Semver {
     }
 
     /**
+     * @inheritdoc CrossDomainMessenger
+     */
+    function sendMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit
+    ) external payable override {
+
+        // Triggers a message to the other messenger. Note that the amount of gas provided to the
+        // message is the amount of gas requested by the user PLUS the base gas value. We want to
+        // guarantee the property that the call to the target contract will always have at least
+        // the minimum gas limit specified by the user.
+        _sendMessage(
+            0,
+            OTHER_MESSENGER,
+            baseGas(_message, _minGasLimit),
+            abi.encodeWithSelector(
+                L2CrossDomainMessenger.relayMessage.selector,
+                messageNonce(),
+                msg.sender,
+                _target,
+                0,
+                msg.value,
+                _minGasLimit,
+                _message
+            )
+        );
+
+        emit SentMessage(_target, msg.sender, _message, messageNonce(), _minGasLimit);
+        emit SentMessageExtension1(msg.sender, 0, msg.value);
+
+        unchecked {
+            ++msgNonce;
+        }
+    }
+
+    /**
      * @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
      *         be executed via cross-chain call from the other messenger OR if the message was
      *         already received once and is currently being replayed.

--- a/packages/contracts-bedrock/contracts/test/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/contracts/test/BenchmarkTest.t.sol
@@ -122,7 +122,7 @@ contract GasBenchMark_OptimismPortal is Portal_Initializer {
 }
 
 contract GasBenchMark_L1CrossDomainMessenger is Messenger_Initializer {
-    function test_sendMessage_benchmark_0() external {
+    function test_sendMessage_benchmark_0_0() external {
         vm.pauseGasMetering();
         setPrevBaseFee(vm, address(op), 1 gwei);
         // The amount of data typically sent during a bridge deposit.
@@ -132,7 +132,17 @@ contract GasBenchMark_L1CrossDomainMessenger is Messenger_Initializer {
         L1Messenger.sendMessage(0, bob, data, uint32(100));
     }
 
-    function test_sendMessage_benchmark_1() external {
+    function test_sendMessage_benchmark_0_1() external {
+        vm.pauseGasMetering();
+        setPrevBaseFee(vm, address(op), 1 gwei);
+        // The amount of data typically sent during a bridge deposit.
+        bytes
+        memory data = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        vm.resumeGasMetering();
+        L1Messenger.sendMessage(bob, data, uint32(100));
+    }
+
+    function test_sendMessage_benchmark_1_0() external {
         vm.pauseGasMetering();
         setPrevBaseFee(vm, address(op), 10 gwei);
         // The amount of data typically sent during a bridge deposit.
@@ -141,7 +151,19 @@ contract GasBenchMark_L1CrossDomainMessenger is Messenger_Initializer {
         vm.resumeGasMetering();
         L1Messenger.sendMessage(0, bob, data, uint32(100));
     }
+
+    function test_sendMessage_benchmark_1_1() external {
+        vm.pauseGasMetering();
+        setPrevBaseFee(vm, address(op), 10 gwei);
+        // The amount of data typically sent during a bridge deposit.
+        bytes
+        memory data = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        vm.resumeGasMetering();
+        L1Messenger.sendMessage(bob, data, uint32(100));
+    }
 }
+
+
 
 contract GasBenchMark_L1StandardBridge_Deposit is Bridge_Initializer {
     function setUp() public virtual override {

--- a/packages/contracts-bedrock/contracts/test/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1CrossDomainMessenger.t.sol
@@ -35,7 +35,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
     // sendMessage: should be able to send a single message
     // TODO: this same test needs to be done with the legacy message type
     // by setting the message version to 0
-    function test_sendMessage_succeeds() external {
+    function test_sendMessage_succeeds_0() external {
         // deposit transaction on the optimism portal should be called
         vm.expectCall(
             address(op),
@@ -89,6 +89,62 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
 
         vm.prank(alice);
         L1Messenger.sendMessage(0, recipient, hex"ff", uint32(100));
+    }
+
+    function test_sendMessage_succeeds_1() external {
+        // deposit transaction on the optimism portal should be called
+        vm.expectCall(
+            address(op),
+            abi.encodeWithSelector(
+                OptimismPortal.depositTransaction.selector,
+                0,
+                Predeploys.L2_CROSS_DOMAIN_MESSENGER,
+                0,
+                L1Messenger.baseGas(hex"ff", 100),
+                false,
+                Encoding.encodeCrossDomainMessage(
+                    L1Messenger.messageNonce(),
+                    alice,
+                    recipient,
+                    0,
+                    0,
+                    100,
+                    hex"ff"
+                )
+            )
+        );
+
+        // TransactionDeposited event
+        vm.expectEmit(true, true, true, true);
+        emitTransactionDeposited(
+            AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger)),
+            Predeploys.L2_CROSS_DOMAIN_MESSENGER,
+            0,
+            0,
+            0,
+            L1Messenger.baseGas(hex"ff", 100),
+            false,
+            Encoding.encodeCrossDomainMessage(
+                L1Messenger.messageNonce(),
+                alice,
+                recipient,
+                0,
+                0,
+                100,
+                hex"ff"
+            )
+        );
+
+        // SentMessage event
+        vm.expectEmit(true, true, true, true);
+        emit SentMessage(recipient, alice, hex"ff", L1Messenger.messageNonce(), 100);
+
+        // SentMessageExtension1 event
+        vm.expectEmit(true, true, true, true);
+        emit SentMessageExtension1(alice, 0, 0);
+
+        vm.prank(alice);
+        L1Messenger.sendMessage(recipient, hex"ff", uint32(100));
     }
 
     // sendMessage: should be able to send the same message twice

--- a/packages/contracts-bedrock/contracts/test/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1ERC721Bridge.t.sol
@@ -70,7 +70,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeCall(
-                L1Messenger.sendMessage,
+                IL1CrossDomainMessenger(address(L1Messenger)).sendMessage,
                 (
                     0,
                     address(otherBridge),
@@ -160,7 +160,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeCall(
-                L1Messenger.sendMessage,
+                IL1CrossDomainMessenger(address(L1Messenger)).sendMessage,
                 (
                     0,
                     address(otherBridge),
@@ -347,4 +347,13 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
             hex"5678"
         );
     }
+}
+
+interface IL1CrossDomainMessenger {
+    function sendMessage(
+        uint256 _ethAmount,
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit
+    ) external payable;
 }

--- a/packages/contracts-bedrock/contracts/test/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1StandardBridge.t.sol
@@ -49,11 +49,11 @@ contract L1StandardBridge_Receive_Test is Bridge_Initializer {
 
         vm.expectEmit(true, true, true, true, address(L1Bridge));
         emit ETHBridgeInitiated(alice, alice, 100, hex"");
-
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         vm.expectCall(
             address(L1Messenger),
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L2Bridge),
                 abi.encodeWithSelector(
@@ -82,6 +82,7 @@ contract PreBridgeETH is Bridge_Initializer {
         uint256 nonce = L1Messenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
 
         bytes memory message = abi.encodeWithSelector(
             L2StandardBridge.finalizeBridgeETH.selector,
@@ -108,7 +109,7 @@ contract PreBridgeETH is Bridge_Initializer {
             address(L1Messenger),
             500,
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L2Bridge),
                 message,
@@ -218,6 +219,7 @@ contract PreBridgeETHTo is Bridge_Initializer {
         uint256 nonce = L1Messenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
 
         if (isLegacy) {
             vm.expectCall(
@@ -246,7 +248,7 @@ contract PreBridgeETHTo is Bridge_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L2Bridge),
                 message,
@@ -353,6 +355,7 @@ contract L1StandardBridge_DepositERC20_Test is Bridge_Initializer {
         uint256 nonce = L1Messenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
 
         // Deal Alice's ERC20 State
         deal(address(L1Token), alice, 100000, true);
@@ -379,7 +382,7 @@ contract L1StandardBridge_DepositERC20_Test is Bridge_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L2Bridge),
                 message,
@@ -458,7 +461,7 @@ contract PreBridgeMNT is Bridge_Initializer {
         uint256 nonce = L1Messenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
-
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         bytes memory message = abi.encodeWithSelector(
             L2StandardBridge.finalizeBridgeMNT.selector,
             alice,
@@ -492,7 +495,7 @@ contract PreBridgeMNT is Bridge_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 500,
                 address(L2Bridge),
                 message,
@@ -617,7 +620,7 @@ contract PreBridgeMNTTo is Bridge_Initializer {
         uint256 nonce = L1Messenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
-
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         vm.deal(alice,1000);
         deal(address(l1MNT), alice, 600);
         vm.prank(alice);
@@ -649,7 +652,7 @@ contract PreBridgeMNTTo is Bridge_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 600,
                 address(L2Bridge),
                 message,
@@ -775,7 +778,7 @@ contract L1StandardBridge_DepositERC20To_Test is Bridge_Initializer {
         uint256 nonce = L1Messenger.messageNonce();
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
-
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         deal(address(L1Token), alice, 100000, true);
         vm.store(address(L1Token), bytes32(uint256(0x2)), bytes32(uint256(100000))); //set total supply
 
@@ -796,7 +799,7 @@ contract L1StandardBridge_DepositERC20To_Test is Bridge_Initializer {
         vm.expectCall(
             address(L1Messenger),
             abi.encodeWithSelector(
-                L1CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L2Bridge),
                 message,

--- a/packages/contracts-bedrock/contracts/test/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2ERC721Bridge.t.sol
@@ -82,7 +82,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         vm.expectCall(
             address(L2Messenger),
             abi.encodeCall(
-                L2Messenger.sendMessage,
+                IL2CrossDomainMessenger(address(L2Messenger)).sendMessage,
                 (
                     0,
                     address(otherBridge),
@@ -168,7 +168,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         vm.expectCall(
             address(L2Messenger),
             abi.encodeCall(
-                L2Messenger.sendMessage,
+                IL2CrossDomainMessenger(address(L2Messenger)).sendMessage,
                 (
                     0,
                     address(otherBridge),
@@ -408,4 +408,13 @@ contract NonCompliantERC721 {
     function supportsInterface(bytes4) external pure returns (bool) {
         return false;
     }
+}
+
+interface IL2CrossDomainMessenger {
+    function sendMessage(
+        uint256 _ethAmount,
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit
+    ) external payable;
 }

--- a/packages/contracts-bedrock/contracts/test/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2StandardBridge.t.sol
@@ -91,12 +91,12 @@ contract L2StandardBridge_Test is Bridge_Initializer {
         // SentMessageExtension1 event emitted by the CrossDomainMessenger
         vm.expectEmit(true, true, true, true, address(L2Messenger));
         emit SentMessageExtension1(address(L2Bridge), 100, 0);
-
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         vm.expectCall(
             address(L2Messenger),
             100,
             abi.encodeWithSelector(
-                L2CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L1Bridge),
                 message,
@@ -215,6 +215,7 @@ contract PreBridgeERC20 is Bridge_Initializer {
         deal(_l2Token, alice, 100, true);
         assertEq(ERC20(_l2Token).balanceOf(alice), 100);
         uint256 nonce = L2Messenger.messageNonce();
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         bytes memory message = abi.encodeWithSelector(
             L1StandardBridge.finalizeBridgeERC20.selector,
             address(L1Token),
@@ -269,7 +270,7 @@ contract PreBridgeERC20 is Bridge_Initializer {
         vm.expectCall(
             address(L2Messenger),
             abi.encodeWithSelector(
-                L2CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L1Bridge),
                 message,
@@ -445,7 +446,7 @@ contract PreBridgeERC20To is Bridge_Initializer {
         // SentMessageExtension1 event emitted by the CrossDomainMessenger
         vm.expectEmit(true, true, true, true, address(L2Messenger));
         emit SentMessageExtension1(address(L2Bridge), 0, 0);
-
+        bytes4 selector = bytes4(keccak256("sendMessage(uint256,address,bytes,uint32)"));
         if (_isLegacy) {
             vm.expectCall(
                 address(L2Bridge),
@@ -476,7 +477,7 @@ contract PreBridgeERC20To is Bridge_Initializer {
         vm.expectCall(
             address(L2Messenger),
             abi.encodeWithSelector(
-                L2CrossDomainMessenger.sendMessage.selector,
+                selector,
                 0,
                 address(L1Bridge),
                 message,

--- a/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
@@ -305,6 +305,49 @@ abstract contract CrossDomainMessenger is
     }
 
     /**
+* @notice Sends a message to some target address on the other chain. Note that if the call
+     *         always reverts, then the message will be unrelayable, and any ETH sent will be
+     *         permanently locked. The same will occur if the target on the other chain is
+     *         considered unsafe (see the _isUnsafeTarget() function).
+     *
+     * @param _target                       Target contract or wallet address.
+     * @param _message                      Message to trigger the target address with.
+     * @param _minGasLimit                  Minimum gas limit that the message can be executed with.
+     */
+    function sendMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit
+    ) external payable virtual {
+        // Triggers a message to the other messenger. Note that the amount of gas provided to the
+        // message is the amount of gas requested by the user PLUS the base gas value. We want to
+        // guarantee the property that the call to the target contract will always have at least
+        // the minimum gas limit specified by the user.
+        _sendMessage(
+            0,
+            OTHER_MESSENGER,
+            baseGas(_message, _minGasLimit),
+            abi.encodeWithSelector(
+                this.relayMessage.selector,
+                messageNonce(),
+                msg.sender,
+                _target,
+                0,
+                msg.value,
+                _minGasLimit,
+                _message
+            )
+        );
+
+        emit SentMessage(_target, msg.sender, _message, messageNonce(), _minGasLimit);
+        emit SentMessageExtension1(msg.sender, 0, msg.value);
+
+        unchecked {
+            ++msgNonce;
+        }
+    }
+
+    /**
      * @notice Relays a message that was sent by the other CrossDomainMessenger contract. Can only
      *         be executed via cross-chain call from the other messenger OR if the message was
      *         already received once and is currently being replayed.


### PR DESCRIPTION
Core changes:

- To ensure a smooth transition from V1 to V2 for custom bridges, retain the original sendMessage interface of the mantle V1 crossDomainMessage.
- At the same time, rename the existing sendMessage to sendMessageMantleBedrock for use by our standard bridge.