### PR TITLE
R4R: Bump OptimismPortal Semver version

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -162,7 +162,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         bool _paused,
         SystemConfig _config,
         address _l1MNT
-    ) Semver(1, 6, 0) {
+    ) Semver(1, 7, 0) {
         L2_ORACLE = _l2Oracle;
         GUARDIAN = _guardian;
         SYSTEM_CONFIG = _config;


### PR DESCRIPTION
As https://github.com/mantlenetworkio/mantle-v2/pull/89 import an interface update, it is a backwards-incompatible change. So here, we need to bump the OptimismPortal Semver version.