### PR TITLE
R4R: add gas consumption for hash message

### DIFF
--- a/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
@@ -163,6 +163,16 @@ abstract contract CrossDomainMessenger is
     uint64 public constant RELAY_GAS_CHECK_BUFFER = 5_000;
 
     /**
+     * @notice BASE gas reserved for Hashing.hashCrossDomainMessage
+     */
+    uint64 public constant HASH_MESSAGE_BASE_GAS = 800;
+
+    /**
+     * @notice Extra gas reserved for per-byte in Hashing.hashCrossDomainMessage
+     */
+    uint64 public constant HASH_MESSAGE_GAS_PER_BYTE = 2;
+
+    /**
      * @notice Address of the paired CrossDomainMessenger contract on the other chain.
      */
     address public immutable OTHER_MESSENGER;
@@ -517,6 +527,8 @@ abstract contract CrossDomainMessenger is
             RELAY_CONSTANT_OVERHEAD +
             // Calldata overhead
             (uint64(_message.length) * MIN_GAS_CALLDATA_OVERHEAD) +
+            // Hash message
+            (uint64(_message.length) * HASH_MESSAGE_GAS_PER_BYTE) + HASH_MESSAGE_BASE_GAS +
             // Dynamic overhead (EIP-150)
             ((_minGasLimit * MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR) /
                 MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR) +


### PR DESCRIPTION
I have checked some examples.

* 1. message: `0x1635f5fd0000000000000000000000007d99f3a8d64d3b713981918038c283325e8bbb310000000000000000000000007d99f3a8d64d3b713981918038c283325e8bbb3100000000000000000000000000000000000000000000000185c9274d940e23fc00000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000`
When message length is 164 , the gas consumption for `Hashing.hashCrossDomainMessage1` is 1195.

* 2. message: 
`0xa9f9e6750000000000000000000000006b175474e89094c44da98b954eedeac495271d0f000000000000000000000000da10009cbd5d07dd0cecc66161fc93d7c9000da10000000000000000000000004cdfaba751f80a76bb0ee3bd2278d0c82d8021b10000000000000000000000004cdfaba751f80a76bb0ee3bd2278d0c82d8021b100000000000000000000000000000000000000000000065a85247a1931d9909400000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000000`
When message length is 228 , the gas consumption for `Hashing.hashCrossDomainMessage1` is 1320.

So approximately, the gas consumption follows this approximately: 

```
gas = 800+2*(messageLength)
```

