### PR TITLE
R4R: ethclient: use 'input', not 'data' as field for transaction input

### DIFF
--- a/l2geth/ethclient/ethclient.go
+++ b/l2geth/ethclient/ethclient.go
@@ -554,7 +554,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["data"] = hexutil.Bytes(msg.Data)
+		arg["input"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)


### PR DESCRIPTION
Reference: https://github.com/ethereum/go-ethereum/pull/28078