### PR TITLE
fix oz audit issue m-01

### DIFF
--- a/op-service/eigenda/da_proxy.go
+++ b/op-service/eigenda/da_proxy.go
@@ -25,6 +25,9 @@ var ErrNotFound = errors.New("not found")
 // ErrInvalidInput is returned when the input is not valid for posting to the DA storage.
 var ErrInvalidInput = errors.New("invalid input")
 
+// ErrNetwork is returned when there is a eigenda network error.
+var ErrNetwork = errors.New("eigenda network error")
+
 // NewEigenDAClient is an HTTP client to communicate with EigenDA Proxy.
 // It creates commitments and retrieves input data + verifies if needed.
 type EigenDAClient struct {
@@ -147,11 +150,11 @@ func (c *EigenDAClient) DisperseBlob(ctx context.Context, img []byte) (*disperse
 	resp, err := c.disperseClient.Do(req)
 	done(err)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to post store data orirgin error: %w error: %w", err, ErrNetwork)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to store data: %v", resp.StatusCode)
+		return nil, fmt.Errorf("failed to store data status code: %v error: %w", resp.StatusCode, ErrNetwork)
 	}
 
 	b, err := io.ReadAll(resp.Body)

--- a/op-service/eigenda/da_proxy_test.go
+++ b/op-service/eigenda/da_proxy_test.go
@@ -123,49 +123,106 @@ func TestNewEigenDAProxy_RetrieveBlobWithCommitment(t *testing.T) {
 
 func TestNewEigenDAProxy_DisperseBlob(t *testing.T) {
 	type fields struct {
-		proxyUrl     string
-		disperserUrl string
-		log          log.Logger
+		client *EigenDAClient
 	}
 	type args struct {
 		ctx context.Context
 		img []byte
 	}
+
+	logger := log.New()
+	metrics := &mockMetrics{}
+
+	client := NewEigenDAClient(Config{
+		ProxyUrl:            "http://localhost:3100",
+		DisperserUrl:        "disperser-holesky.eigenda.xyz:443",
+		DisperseBlobTimeout: 10 * time.Minute,
+		RetrieveBlobTimeout: 10 * time.Second,
+	}, logger, metrics)
+
+	invalidClient := NewEigenDAClient(Config{
+		ProxyUrl:            "http://localhost:3333",
+		DisperserUrl:        "disperser-holesky.eigenda.xyz:443",
+		DisperseBlobTimeout: 10 * time.Minute,
+		RetrieveBlobTimeout: 10 * time.Second,
+	}, logger, metrics)
+
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *disperser.BlobInfo
-		wantErr bool
+		name           string
+		fields         fields
+		args           args
+		want           *disperser.BlobInfo
+		wantErr        bool
+		wantNetworkErr bool
 	}{
 		{
 			name: "t1",
 			fields: fields{
-				proxyUrl:     "http://127.0.0.1:3100",
-				disperserUrl: "disperser-holesky.eigenda.xyz:443",
-				log:          log.New("test"),
+				client: client,
 			},
 			args: args{
 				ctx: context.Background(),
 				img: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 			},
-			wantErr: false,
+		},
+		{
+			name: "t2",
+			fields: fields{
+				client: invalidClient,
+			},
+			args: args{
+				ctx: context.Background(),
+				img: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+			},
+			wantErr:        true,
+			wantNetworkErr: true,
+		},
+		{
+			name: "t3",
+			fields: fields{
+				client: client,
+			},
+			args: args{
+				ctx: context.Background(),
+				img: make([]byte, 30*1024*1024), //larger than eigenda throughput limit
+			},
+			wantErr:        true,
+			wantNetworkErr: true,
+		},
+		{
+			name: "t4",
+			fields: fields{
+				client: client,
+			},
+			args: args{
+				ctx: context.Background(),
+				img: []byte{}, //empty data error
+			},
+			wantErr:        true,
+			wantNetworkErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &EigenDAClient{
-				proxyUrl:     tt.fields.proxyUrl,
-				disperserUrl: tt.fields.disperserUrl,
-				log:          tt.fields.log,
-			}
-			got, err := c.DisperseBlob(tt.args.ctx, tt.args.img)
+			got, err := tt.fields.client.DisperseBlob(tt.args.ctx, tt.args.img)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EigenDAClient.DisperseBlob() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			commitment, err := EncodeCommitment(got)
-			fmt.Printf("%v 0x%x\n", err, commitment)
+			if tt.wantErr {
+				require.Error(t, err)
+				t.Logf("error: %v", err)
+			}
+			if tt.wantNetworkErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrNetwork)
+				t.Logf("network error: %v", err)
+			}
+			if !tt.wantErr {
+				commitment, err := EncodeCommitment(got)
+				require.NoError(t, err)
+				fmt.Printf("%v 0x%x\n", err, commitment)
+			}
 		})
 	}
 }


### PR DESCRIPTION
M-01 Inefficient Error Handling and Timeout in loopEigenDaLoop

The [loopEigenDa function](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver_da.go#L208-L310) of the BatchSubmitter attempts to call [disperseEigenDaData](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver_da.go#L237) within a retry loop that continues for either a fixed number of retries ([EigenRPCRetryNum](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver_da.go#L235)) or until a timeout ([DisperseBlobTimeout](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver_da.go#L234)) is reached. However, the implementation neglects to properly handle errors returned by disperseEigenDaData. Instead of classifying or acting on the errors, the loop merely logs them and retries, effectively waiting for the entire DisperseBlobTimeout duration, even in cases where the operation cannot succeed due to permanent or critical errors.
This oversight can lead to inefficient resource utilization and unnecessary delays. In scenarios where a critical error occurs (e.g., invalid input data or persistent configuration issues), the loop will still continue retrying until the timeout expires. This results in wasted computation time, potential bottlenecks in the rollup process, and delayed submission of transaction data. Furthermore, this behavior can obscure the root cause of errors in the logs, as the same error is repeatedly logged without actionable resolution.
To address this issue, the error handling logic should be enhanced to distinguish between transient errors (e.g., network issues) and permanent ones (e.g., invalid data). For transient errors, the loop can continue with retries, potentially implementing exponential backoff to reduce retry frequency over time. For permanent errors, the loop should exit immediately to avoid unnecessary delays. Additionally, the timeout check should be performed at the beginning of each retry iteration to ensure that retries do not continue beyond the configured timeout.