### PR TITLE
fix the oz audit issuse l-02

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-service/eigenda"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
@@ -187,6 +188,13 @@ func (c CLIConfig) Check() error {
 	}
 	if err := c.EigenDAConfig.Check(); err != nil {
 		return err
+	}
+
+	//Used to ensure that when using an Ethereum blob, a single frame is not larger than MaxBlobDataSize * MaxblobNum
+	//Considering that the frame needs to go through rlp. EncodeToBytes before submitting da, the maximum size after encoding cannot be accurately calculated.
+	//So MaxL1TxSize > MaxBlobDataSize is used here to make a rough judgment
+	if c.MaxL1TxSize > eth.MaxBlobDataSize {
+		return errors.New("MaxL1TxSize must less than MaxBlobDataSize")
 	}
 	return nil
 }

--- a/op-batcher/batcher/driver_da.go
+++ b/op-batcher/batcher/driver_da.go
@@ -339,6 +339,11 @@ func (l *BatchSubmitter) blobTxCandidates(data [][]byte) ([]*txmgr.TxCandidate, 
 		}
 
 		if len(nextEncodeData) > se.MaxBlobDataSize*MaxblobNum {
+			if len(encodeData) == 0 {
+				err := fmt.Errorf("single frame data size %d larger than max blob transaction maximum size", len(nextEncodeData))
+				l.log.Error("empty encodeData", "err", err)
+				return nil, err
+			}
 			blobs := []*se.Blob{}
 			for idx := 0; idx < len(encodeData); idx += se.MaxBlobDataSize {
 				blobData := encodeData[idx : idx+minInt(len(encodeData)-idx, se.MaxBlobDataSize)]


### PR DESCRIPTION
L-02 Inadequate Handling of Single Large Data Frames in blobTxCandidates

In the [blobTxCandidates function](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver_da.go#L327-L384), the code assumes that data exceeding the size limit (se.MaxBlobDataSize * MaxblobNum) results from the aggregation of multiple frames. However, it does not account for the possibility that a single frame (frameData) could individually exceed the maximum size. When this occurs, the function [appends](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver_da.go#L334) the oversized frame to dataInTx and proceeds without any special handling, which may lead to unintended behavior during blob creation.
If a single frame exceeds the maximum blob size, the function does not split it into smaller chunks or handle the error explicitly. This can result in the generation of transaction candidates with empty blobs or transaction candidates with an amount of blobs which exceeds the configured amount of maximum blobs (MaxblobNum), which is currently set to 4.
We recommend to introduce explicit handling for single frames that exceed the maximum size. Before appending a frame to dataInTx, check whether the frame itself exceeds the size limit. If it does, log an error and return an appropriate error message. Alternatively, implement logic to split oversized frames into smaller chunks before proceeding. Another solution could be to ensure a single frame will always fit in a single blob transaction by enforcing the configured [MaxFrameSize](https://github.com/mantlenetworkio/mantle-v2/blob/c77cb6e9f44a60f6d25de54bd3d52731de8bdda9/op-batcher/batcher/driver.go#L108) is smaller than the maximum size (se.MaxBlobDataSize * MaxblobNum). Adding this check will ensure robust handling of all edge cases.