### PR TITLE
gas-oracle: introduce operator fee and its updating process

### DIFF
--- a/gas-oracle/Makefile
+++ b/gas-oracle/Makefile
@@ -7,7 +7,7 @@ LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.GitVersion=$(VERSION)
 LDFLAGS :=-ldflags "$(LDFLAGSSTRING)"
 
-CONTRACTS_PATH := "../../packages/contracts-bedrock/artifacts/contracts"
+CONTRACTS_PATH := "../packages/contracts-bedrock/artifacts/contracts"
 
 gas-oracle:
 	env GO111MODULE=on go build -v $(LDFLAGS) -o ./bin/gas-oracle ./main.go

--- a/gas-oracle/abis/GasPriceOracle.json
+++ b/gas-oracle/abis/GasPriceOracle.json
@@ -1,284 +1,439 @@
-[
-  {
-    "inputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOperator",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOperator",
-        "type": "address"
-      }
-    ],
-    "name": "OperatorUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "previousTokenRatio",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "newTokenRatio",
-        "type": "uint256"
-      }
-    ],
-    "name": "TokenRatioUpdated",
-    "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "DECIMALS",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "baseFee",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "decimals",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "gasPrice",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes",
-        "name": "_data",
-        "type": "bytes"
-      }
-    ],
-    "name": "getL1Fee",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes",
-        "name": "_data",
-        "type": "bytes"
-      }
-    ],
-    "name": "getL1GasUsed",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "l1BaseFee",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "operator",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "overhead",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "scalar",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_operator",
-        "type": "address"
-      }
-    ],
-    "name": "setOperator",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_tokenRatio",
-        "type": "uint256"
-      }
-    ],
-    "name": "setTokenRatio",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "tokenRatio",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_owner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "version",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
+{
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "DECIMALS",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "_gap",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "baseFee",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "decimals",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "gasPrice",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getL1Fee",
+      "inputs": [
+        {
+          "name": "_data",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getL1GasUsed",
+      "inputs": [
+        {
+          "name": "_data",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getOperatorFee",
+      "inputs": [
+        {
+          "name": "_gasUsed",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "isSkadi",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "l1BaseFee",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "operator",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "operatorFeeConstant",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "operatorFeeScalar",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "overhead",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "scalar",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setIsSkadi",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setOperator",
+      "inputs": [
+        {
+          "name": "_operator",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setOperatorFeeConstant",
+      "inputs": [
+        {
+          "name": "_operatorFeeConstant",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setOperatorFeeScalar",
+      "inputs": [
+        {
+          "name": "_operatorFeeScalar",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setTokenRatio",
+      "inputs": [
+        {
+          "name": "_tokenRatio",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "tokenRatio",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        {
+          "name": "_owner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "version",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "OperatorFeeConstantUpdated",
+      "inputs": [
+        {
+          "name": "previousOperatorFeeConstant",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "newOperatorFeeConstant",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OperatorFeeScalarUpdated",
+      "inputs": [
+        {
+          "name": "previousOperatorFeeScalar",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "newOperatorFeeScalar",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OperatorUpdated",
+      "inputs": [
+        {
+          "name": "previousOperator",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOperator",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "previousOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TokenRatioUpdated",
+      "inputs": [
+        {
+          "name": "previousTokenRatio",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "newTokenRatio",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    }
+  ],
+  "bytecode": {
+    "object": "0x60e060405234801561001057600080fd5b506001608081905260a052600060c05260805160a05160c0516113f661004f6000396000610718015260006106ef015260006106c601526113f66000f3fe608060405234801561001057600080fd5b50600436106101985760003560e01c806356976658116100e3578063dab3b3da1161008c578063f2fde38b11610066578063f2fde38b14610329578063f45e65d81461033c578063fe173b97146102b757600080fd5b8063dab3b3da146102f0578063de26c4a114610303578063e38e91f91461031657600080fd5b80636ef25c3a116100bd5780636ef25c3a146102b75780638da5cb5b146102bd578063b3ab15fb146102dd57600080fd5b80635697665814610242578063570ca7351461025f5780635d71ff8f146102a457600080fd5b8063313ce567116101455780634d5d9a2a1161011f5780634d5d9a2a1461021c578063519b4bd31461022557806354fd4d501461022d57600080fd5b8063313ce567146101ef57806332e70fea146101f657806349948e0e1461020957600080fd5b80632312b618116101765780632312b618146101ca578063275aedd2146101d45780632e0f2625146101e757600080fd5b806306f837d31461019d5780630c18c162146101b957806316d3bc7f146101c1575b600080fd5b6101a660005481565b6040519081526020015b60405180910390f35b6101a6610344565b6101a660035481565b6101d26103ec565b005b6101a66101e2366004610f00565b610507565b6101a6600681565b60066101a6565b6101d2610204366004610f00565b610575565b6101a6610217366004610f48565b61062f565b6101a660045481565b6101a661063a565b6102356106bf565b6040516101b09190611047565b600f5461024f9060ff1681565b60405190151581526020016101b0565b60025461027f9073ffffffffffffffffffffffffffffffffffffffff1681565b60405173ffffffffffffffffffffffffffffffffffffffff90911681526020016101b0565b6101d26102b2366004610f00565b610762565b486101a6565b60015461027f9073ffffffffffffffffffffffffffffffffffffffff1681565b6101d26102eb366004611098565b61081c565b6101a66102fe366004610f00565b610914565b6101a6610311366004610f48565b61092b565b6101d2610324366004610f00565b610948565b6101d2610337366004611098565b610a00565b6101a6610b75565b600f5460009060ff16156103df576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602860248201527f47617350726963654f7261636c653a206f76657268656164282920697320646560448201527f707265636174656400000000000000000000000000000000000000000000000060648201526084015b60405180910390fd5b6103e7610c13565b905090565b60025473ffffffffffffffffffffffffffffffffffffffff16331461046d576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b600f5460ff16156104da576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601360248201527f6973536b61646920616c7265616479207365740000000000000000000000000060448201526064016103d6565b600f80547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055565b600f5460009060ff1661051c57506000919050565b60045461056f9061056090620f4240907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8615878302888104909314170117611133565b60035481019081106000031790565b92915050565b60025473ffffffffffffffffffffffffffffffffffffffff1633146105f6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b6003805490829055604051829082907f08a9bc8992a7c4fa053bafee70f234ebf754c491d16759a28adf47e3cd9375b990600090a35050565b600061056f82610c74565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16635cf249696040518163ffffffff1660e01b8152600401602060405180830381865afa15801561069b573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906103e79190611147565b60606106ea7f0000000000000000000000000000000000000000000000000000000000000000610cda565b6107137f0000000000000000000000000000000000000000000000000000000000000000610cda565b61073c7f0000000000000000000000000000000000000000000000000000000000000000610cda565b60405160200161074e93929190611160565b604051602081830303815290604052905090565b60025473ffffffffffffffffffffffffffffffffffffffff1633146107e3576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b6004805490829055604051829082907f977ba0b597123a7c26f0d57b10b1ab88e14d4e8676e6629640df681ccf5ffcf290600090a35050565b60015473ffffffffffffffffffffffffffffffffffffffff16331461089d576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616c6c6572206973206e6f7420746865206f776e657200000000000000000060448201526064016103d6565b6002805473ffffffffffffffffffffffffffffffffffffffff8381167fffffffffffffffffffffffff0000000000000000000000000000000000000000831681179093556040519116919082907ffbe5b6cbafb274f445d7fed869dc77a838d8243a22c460de156560e8857cad0390600090a35050565b600581600a811061092457600080fd5b0154905081565b6000610935610c13565b61093e83610e0f565b61056f91906111d6565b60025473ffffffffffffffffffffffffffffffffffffffff1633146109c9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b600080548282556040519091839183917f5d6ae9db2d6725497bed0302a8212c0db5fdb3bd7d14f188a83b5589089caafd91a35050565b60015473ffffffffffffffffffffffffffffffffffffffff163314610a81576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616c6c6572206973206e6f7420746865206f776e657200000000000000000060448201526064016103d6565b73ffffffffffffffffffffffffffffffffffffffff8116610afe576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f6e6577206f776e657220697320746865207a65726f206164647265737300000060448201526064016103d6565b6001805473ffffffffffffffffffffffffffffffffffffffff8381167fffffffffffffffffffffffff0000000000000000000000000000000000000000831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b600f5460009060ff1615610c0b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602660248201527f47617350726963654f7261636c653a207363616c61722829206973206465707260448201527f656361746564000000000000000000000000000000000000000000000000000060648201526084016103d6565b6103e7610e9f565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16638b239f736040518163ffffffff1660e01b8152600401602060405180830381865afa15801561069b573d6000803e3d6000fd5b600080610c8083610e0f565b90506000610c8c610e9f565b610c9461063a565b610c9c610c13565b610ca690856111d6565b610cb091906111ee565b610cba91906111ee565b9050610cc86006600a61134b565b610cd29082611133565b949350505050565b606081600003610d1d57505060408051808201909152600181527f3000000000000000000000000000000000000000000000000000000000000000602082015290565b8160005b8115610d475780610d3181611357565b9150610d409050600a83611133565b9150610d21565b60008167ffffffffffffffff811115610d6257610d62610f19565b6040519080825280601f01601f191660200182016040528015610d8c576020820181803683370190505b5090505b8415610cd257610da160018361138f565b9150610dae600a866113a6565b610db99060306111d6565b60f81b818381518110610dce57610dce6113ba565b60200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1916908160001a905350610e08600a86611133565b9450610d90565b80516000908190815b81811015610e9257848181518110610e3257610e326113ba565b01602001517fff0000000000000000000000000000000000000000000000000000000000000016600003610e7257610e6b6004846111d6565b9250610e80565b610e7d6010846111d6565b92505b80610e8a81611357565b915050610e18565b50610cd2826104406111d6565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16639e8c49666040518163ffffffff1660e01b8152600401602060405180830381865afa15801561069b573d6000803e3d6000fd5b600060208284031215610f1257600080fd5b5035919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b600060208284031215610f5a57600080fd5b813567ffffffffffffffff80821115610f7257600080fd5b818401915084601f830112610f8657600080fd5b813581811115610f9857610f98610f19565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f01168101908382118183101715610fde57610fde610f19565b81604052828152876020848701011115610ff757600080fd5b826020860160208301376000928101602001929092525095945050505050565b60005b8381101561103257818101518382015260200161101a565b83811115611041576000848401525b50505050565b6020815260008251806020840152611066816040850160208701611017565b601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0169190910160400192915050565b6000602082840312156110aa57600080fd5b813573ffffffffffffffffffffffffffffffffffffffff811681146110ce57600080fd5b9392505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b600082611142576111426110d5565b500490565b60006020828403121561115957600080fd5b5051919050565b60008451611172818460208901611017565b80830190507f2e0000000000000000000000000000000000000000000000000000000000000080825285516111ae816001850160208a01611017565b600192019182015283516111c9816002840160208801611017565b0160020195945050505050565b600082198211156111e9576111e9611104565b500190565b6000817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff048311821515161561122657611226611104565b500290565b600181815b8085111561128457817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0482111561126a5761126a611104565b8085161561127757918102915b93841c9390800290611230565b509250929050565b60008261129b5750600161056f565b816112a85750600061056f565b81600181146112be57600281146112c8576112e4565b600191505061056f565b60ff8411156112d9576112d9611104565b50506001821b61056f565b5060208310610133831016604e8410600b8410161715611307575081810a61056f565b611311838361122b565b807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0482111561134357611343611104565b029392505050565b60006110ce838361128c565b60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff820361138857611388611104565b5060010190565b6000828210156113a1576113a1611104565b500390565b6000826113b5576113b56110d5565b500690565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fdfea164736f6c634300080f000a",
+    "sourceMap": "1200:7119:8:-:0;;;1617:33;;;;;;;;;-1:-1:-1;1638:1:8;826:22:44;;;;858;;1644:1:8;890:22:44;;1200:7119:8;;;;;;;;;;;;;;;;;;;;;;;;",
+    "linkReferences": {}
   }
-]
+}

--- a/gas-oracle/bindings/gaspriceoracle.go
+++ b/gas-oracle/bindings/gaspriceoracle.go
@@ -31,8 +31,8 @@ var (
 
 // GasPriceOracleMetaData contains all meta data concerning the GasPriceOracle contract.
 var GasPriceOracleMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOperator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOperator\",\"type\":\"address\"}],\"name\":\"OperatorUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"previousTokenRatio\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"newTokenRatio\",\"type\":\"uint256\"}],\"name\":\"TokenRatioUpdated\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DECIMALS\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"baseFee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"gasPrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"getL1Fee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"getL1GasUsed\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l1BaseFee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"operator\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"overhead\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"scalar\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_operator\",\"type\":\"address\"}],\"name\":\"setOperator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_tokenRatio\",\"type\":\"uint256\"}],\"name\":\"setTokenRatio\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"tokenRatio\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_owner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
-	Bin: "0x60e060405234801561001057600080fd5b5060016080819052600060a081905260c081905280610e8561004a823960006103ce015260006103a50152600061037c0152610e856000f3fe608060405234801561001057600080fd5b50600436106101005760003560e01c80636ef25c3a11610097578063e38e91f911610066578063e38e91f9146101fb578063f2fde38b1461020e578063f45e65d814610221578063fe173b97146101ad57600080fd5b80636ef25c3a146101ad5780638da5cb5b146101b3578063b3ab15fb146101d3578063de26c4a1146101e857600080fd5b806349948e0e116100d357806349948e0e14610138578063519b4bd31461014b57806354fd4d5014610153578063570ca7351461016857600080fd5b806306f837d3146101055780630c18c162146101215780632e0f262514610129578063313ce56714610131575b600080fd5b61010e60005481565b6040519081526020015b60405180910390f35b61010e610229565b61010e600681565b600661010e565b61010e6101463660046109bc565b6102b3565b61010e610314565b61015b610375565b6040516101189190610abb565b6002546101889073ffffffffffffffffffffffffffffffffffffffff1681565b60405173ffffffffffffffffffffffffffffffffffffffff9091168152602001610118565b4861010e565b6001546101889073ffffffffffffffffffffffffffffffffffffffff1681565b6101e66101e1366004610b0c565b610418565b005b61010e6101f63660046109bc565b610515565b6101e6610209366004610b49565b6105c4565b6101e661021c366004610b0c565b61067a565b61010e6107ef565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16638b239f736040518163ffffffff1660e01b8152600401602060405180830381865afa15801561028a573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906102ae9190610b62565b905090565b6000806102bf83610515565b905060006102cb610314565b6102d59083610baa565b905060006102e56006600a610d09565b905060006102f16107ef565b6102fb9084610baa565b905060006103098383610d44565b979650505050505050565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16635cf249696040518163ffffffff1660e01b8152600401602060405180830381865afa15801561028a573d6000803e3d6000fd5b60606103a07f0000000000000000000000000000000000000000000000000000000000000000610850565b6103c97f0000000000000000000000000000000000000000000000000000000000000000610850565b6103f27f0000000000000000000000000000000000000000000000000000000000000000610850565b60405160200161040493929190610d58565b604051602081830303815290604052905090565b60015473ffffffffffffffffffffffffffffffffffffffff16331461049e576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616c6c6572206973206e6f7420746865206f776e657200000000000000000060448201526064015b60405180910390fd5b6002805473ffffffffffffffffffffffffffffffffffffffff8381167fffffffffffffffffffffffff0000000000000000000000000000000000000000831681179093556040519116919082907ffbe5b6cbafb274f445d7fed869dc77a838d8243a22c460de156560e8857cad0390600090a35050565b80516000908190815b818110156105985784818151811061053857610538610dce565b01602001517fff000000000000000000000000000000000000000000000000000000000000001660000361057857610571600484610dfd565b9250610586565b610583601084610dfd565b92505b8061059081610e15565b91505061051e565b5060006105a3610229565b6105ad9084610dfd565b90506105bb81610440610dfd565b95945050505050565b60025473ffffffffffffffffffffffffffffffffffffffff163314610645576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f720000000000006044820152606401610495565b60008181556040518291829182917f5d6ae9db2d6725497bed0302a8212c0db5fdb3bd7d14f188a83b5589089caafd91a35050565b60015473ffffffffffffffffffffffffffffffffffffffff1633146106fb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616c6c6572206973206e6f7420746865206f776e65720000000000000000006044820152606401610495565b73ffffffffffffffffffffffffffffffffffffffff8116610778576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f6e6577206f776e657220697320746865207a65726f20616464726573730000006044820152606401610495565b6001805473ffffffffffffffffffffffffffffffffffffffff8381167fffffffffffffffffffffffff0000000000000000000000000000000000000000831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16639e8c49666040518163ffffffff1660e01b8152600401602060405180830381865afa15801561028a573d6000803e3d6000fd5b60608160000361089357505060408051808201909152600181527f3000000000000000000000000000000000000000000000000000000000000000602082015290565b8160005b81156108bd57806108a781610e15565b91506108b69050600a83610d44565b9150610897565b60008167ffffffffffffffff8111156108d8576108d861098d565b6040519080825280601f01601f191660200182016040528015610902576020820181803683370190505b5090505b841561098557610917600183610e4d565b9150610924600a86610e64565b61092f906030610dfd565b60f81b81838151811061094457610944610dce565b60200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1916908160001a90535061097e600a86610d44565b9450610906565b949350505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6000602082840312156109ce57600080fd5b813567ffffffffffffffff808211156109e657600080fd5b818401915084601f8301126109fa57600080fd5b813581811115610a0c57610a0c61098d565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f01168101908382118183101715610a5257610a5261098d565b81604052828152876020848701011115610a6b57600080fd5b826020860160208301376000928101602001929092525095945050505050565b60005b83811015610aa6578181015183820152602001610a8e565b83811115610ab5576000848401525b50505050565b6020815260008251806020840152610ada816040850160208701610a8b565b601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0169190910160400192915050565b600060208284031215610b1e57600080fd5b813573ffffffffffffffffffffffffffffffffffffffff81168114610b4257600080fd5b9392505050565b600060208284031215610b5b57600080fd5b5035919050565b600060208284031215610b7457600080fd5b5051919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b6000817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0483118215151615610be257610be2610b7b565b500290565b600181815b80851115610c4057817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff04821115610c2657610c26610b7b565b80851615610c3357918102915b93841c9390800290610bec565b509250929050565b600082610c5757506001610d03565b81610c6457506000610d03565b8160018114610c7a5760028114610c8457610ca0565b6001915050610d03565b60ff841115610c9557610c95610b7b565b50506001821b610d03565b5060208310610133831016604e8410600b8410161715610cc3575081810a610d03565b610ccd8383610be7565b807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff04821115610cff57610cff610b7b565b0290505b92915050565b6000610b428383610c48565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b600082610d5357610d53610d15565b500490565b60008451610d6a818460208901610a8b565b80830190507f2e000000000000000000000000000000000000000000000000000000000000008082528551610da6816001850160208a01610a8b565b60019201918201528351610dc1816002840160208801610a8b565b0160020195945050505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fd5b60008219821115610e1057610e10610b7b565b500190565b60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203610e4657610e46610b7b565b5060010190565b600082821015610e5f57610e5f610b7b565b500390565b600082610e7357610e73610d15565b50069056fea164736f6c634300080f000a",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DECIMALS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"_gap\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"baseFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decimals\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"gasPrice\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getL1Fee\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getL1GasUsed\",\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getOperatorFee\",\"inputs\":[{\"name\":\"_gasUsed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isSkadi\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"l1BaseFee\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorFeeConstant\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"operatorFeeScalar\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"overhead\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"scalar\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setIsSkadi\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setOperator\",\"inputs\":[{\"name\":\"_operator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setOperatorFeeConstant\",\"inputs\":[{\"name\":\"_operatorFeeConstant\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setOperatorFeeScalar\",\"inputs\":[{\"name\":\"_operatorFeeScalar\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTokenRatio\",\"inputs\":[{\"name\":\"_tokenRatio\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"tokenRatio\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"version\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"OperatorFeeConstantUpdated\",\"inputs\":[{\"name\":\"previousOperatorFeeConstant\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"newOperatorFeeConstant\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorFeeScalarUpdated\",\"inputs\":[{\"name\":\"previousOperatorFeeScalar\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"newOperatorFeeScalar\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OperatorUpdated\",\"inputs\":[{\"name\":\"previousOperator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOperator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TokenRatioUpdated\",\"inputs\":[{\"name\":\"previousTokenRatio\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"newTokenRatio\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false}]",
+	Bin: "0x60e060405234801561001057600080fd5b506001608081905260a052600060c05260805160a05160c0516113f661004f6000396000610718015260006106ef015260006106c601526113f66000f3fe608060405234801561001057600080fd5b50600436106101985760003560e01c806356976658116100e3578063dab3b3da1161008c578063f2fde38b11610066578063f2fde38b14610329578063f45e65d81461033c578063fe173b97146102b757600080fd5b8063dab3b3da146102f0578063de26c4a114610303578063e38e91f91461031657600080fd5b80636ef25c3a116100bd5780636ef25c3a146102b75780638da5cb5b146102bd578063b3ab15fb146102dd57600080fd5b80635697665814610242578063570ca7351461025f5780635d71ff8f146102a457600080fd5b8063313ce567116101455780634d5d9a2a1161011f5780634d5d9a2a1461021c578063519b4bd31461022557806354fd4d501461022d57600080fd5b8063313ce567146101ef57806332e70fea146101f657806349948e0e1461020957600080fd5b80632312b618116101765780632312b618146101ca578063275aedd2146101d45780632e0f2625146101e757600080fd5b806306f837d31461019d5780630c18c162146101b957806316d3bc7f146101c1575b600080fd5b6101a660005481565b6040519081526020015b60405180910390f35b6101a6610344565b6101a660035481565b6101d26103ec565b005b6101a66101e2366004610f00565b610507565b6101a6600681565b60066101a6565b6101d2610204366004610f00565b610575565b6101a6610217366004610f48565b61062f565b6101a660045481565b6101a661063a565b6102356106bf565b6040516101b09190611047565b600f5461024f9060ff1681565b60405190151581526020016101b0565b60025461027f9073ffffffffffffffffffffffffffffffffffffffff1681565b60405173ffffffffffffffffffffffffffffffffffffffff90911681526020016101b0565b6101d26102b2366004610f00565b610762565b486101a6565b60015461027f9073ffffffffffffffffffffffffffffffffffffffff1681565b6101d26102eb366004611098565b61081c565b6101a66102fe366004610f00565b610914565b6101a6610311366004610f48565b61092b565b6101d2610324366004610f00565b610948565b6101d2610337366004611098565b610a00565b6101a6610b75565b600f5460009060ff16156103df576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602860248201527f47617350726963654f7261636c653a206f76657268656164282920697320646560448201527f707265636174656400000000000000000000000000000000000000000000000060648201526084015b60405180910390fd5b6103e7610c13565b905090565b60025473ffffffffffffffffffffffffffffffffffffffff16331461046d576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b600f5460ff16156104da576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601360248201527f6973536b61646920616c7265616479207365740000000000000000000000000060448201526064016103d6565b600f80547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00166001179055565b600f5460009060ff1661051c57506000919050565b60045461056f9061056090620f4240907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8615878302888104909314170117611133565b60035481019081106000031790565b92915050565b60025473ffffffffffffffffffffffffffffffffffffffff1633146105f6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b6003805490829055604051829082907f08a9bc8992a7c4fa053bafee70f234ebf754c491d16759a28adf47e3cd9375b990600090a35050565b600061056f82610c74565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16635cf249696040518163ffffffff1660e01b8152600401602060405180830381865afa15801561069b573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906103e79190611147565b60606106ea7f0000000000000000000000000000000000000000000000000000000000000000610cda565b6107137f0000000000000000000000000000000000000000000000000000000000000000610cda565b61073c7f0000000000000000000000000000000000000000000000000000000000000000610cda565b60405160200161074e93929190611160565b604051602081830303815290604052905090565b60025473ffffffffffffffffffffffffffffffffffffffff1633146107e3576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b6004805490829055604051829082907f977ba0b597123a7c26f0d57b10b1ab88e14d4e8676e6629640df681ccf5ffcf290600090a35050565b60015473ffffffffffffffffffffffffffffffffffffffff16331461089d576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616c6c6572206973206e6f7420746865206f776e657200000000000000000060448201526064016103d6565b6002805473ffffffffffffffffffffffffffffffffffffffff8381167fffffffffffffffffffffffff0000000000000000000000000000000000000000831681179093556040519116919082907ffbe5b6cbafb274f445d7fed869dc77a838d8243a22c460de156560e8857cad0390600090a35050565b600581600a811061092457600080fd5b0154905081565b6000610935610c13565b61093e83610e0f565b61056f91906111d6565b60025473ffffffffffffffffffffffffffffffffffffffff1633146109c9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601a60248201527f43616c6c6572206973206e6f7420746865206f70657261746f7200000000000060448201526064016103d6565b600080548282556040519091839183917f5d6ae9db2d6725497bed0302a8212c0db5fdb3bd7d14f188a83b5589089caafd91a35050565b60015473ffffffffffffffffffffffffffffffffffffffff163314610a81576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616c6c6572206973206e6f7420746865206f776e657200000000000000000060448201526064016103d6565b73ffffffffffffffffffffffffffffffffffffffff8116610afe576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f6e6577206f776e657220697320746865207a65726f206164647265737300000060448201526064016103d6565b6001805473ffffffffffffffffffffffffffffffffffffffff8381167fffffffffffffffffffffffff0000000000000000000000000000000000000000831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b600f5460009060ff1615610c0b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602660248201527f47617350726963654f7261636c653a207363616c61722829206973206465707260448201527f656361746564000000000000000000000000000000000000000000000000000060648201526084016103d6565b6103e7610e9f565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16638b239f736040518163ffffffff1660e01b8152600401602060405180830381865afa15801561069b573d6000803e3d6000fd5b600080610c8083610e0f565b90506000610c8c610e9f565b610c9461063a565b610c9c610c13565b610ca690856111d6565b610cb091906111ee565b610cba91906111ee565b9050610cc86006600a61134b565b610cd29082611133565b949350505050565b606081600003610d1d57505060408051808201909152600181527f3000000000000000000000000000000000000000000000000000000000000000602082015290565b8160005b8115610d475780610d3181611357565b9150610d409050600a83611133565b9150610d21565b60008167ffffffffffffffff811115610d6257610d62610f19565b6040519080825280601f01601f191660200182016040528015610d8c576020820181803683370190505b5090505b8415610cd257610da160018361138f565b9150610dae600a866113a6565b610db99060306111d6565b60f81b818381518110610dce57610dce6113ba565b60200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1916908160001a905350610e08600a86611133565b9450610d90565b80516000908190815b81811015610e9257848181518110610e3257610e326113ba565b01602001517fff0000000000000000000000000000000000000000000000000000000000000016600003610e7257610e6b6004846111d6565b9250610e80565b610e7d6010846111d6565b92505b80610e8a81611357565b915050610e18565b50610cd2826104406111d6565b600073420000000000000000000000000000000000001573ffffffffffffffffffffffffffffffffffffffff16639e8c49666040518163ffffffff1660e01b8152600401602060405180830381865afa15801561069b573d6000803e3d6000fd5b600060208284031215610f1257600080fd5b5035919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b600060208284031215610f5a57600080fd5b813567ffffffffffffffff80821115610f7257600080fd5b818401915084601f830112610f8657600080fd5b813581811115610f9857610f98610f19565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f01168101908382118183101715610fde57610fde610f19565b81604052828152876020848701011115610ff757600080fd5b826020860160208301376000928101602001929092525095945050505050565b60005b8381101561103257818101518382015260200161101a565b83811115611041576000848401525b50505050565b6020815260008251806020840152611066816040850160208701611017565b601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0169190910160400192915050565b6000602082840312156110aa57600080fd5b813573ffffffffffffffffffffffffffffffffffffffff811681146110ce57600080fd5b9392505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b600082611142576111426110d5565b500490565b60006020828403121561115957600080fd5b5051919050565b60008451611172818460208901611017565b80830190507f2e0000000000000000000000000000000000000000000000000000000000000080825285516111ae816001850160208a01611017565b600192019182015283516111c9816002840160208801611017565b0160020195945050505050565b600082198211156111e9576111e9611104565b500190565b6000817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff048311821515161561122657611226611104565b500290565b600181815b8085111561128457817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0482111561126a5761126a611104565b8085161561127757918102915b93841c9390800290611230565b509250929050565b60008261129b5750600161056f565b816112a85750600061056f565b81600181146112be57600281146112c8576112e4565b600191505061056f565b60ff8411156112d9576112d9611104565b50506001821b61056f565b5060208310610133831016604e8410600b8410161715611307575081810a61056f565b611311838361122b565b807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0482111561134357611343611104565b029392505050565b60006110ce838361128c565b60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff820361138857611388611104565b5060010190565b6000828210156113a1576113a1611104565b500390565b6000826113b5576113b56110d5565b500690565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fdfea164736f6c634300080f000a",
 }
 
 // GasPriceOracleABI is the input ABI used to generate the binding from.
@@ -233,6 +233,37 @@ func (_GasPriceOracle *GasPriceOracleCallerSession) DECIMALS() (*big.Int, error)
 	return _GasPriceOracle.Contract.DECIMALS(&_GasPriceOracle.CallOpts)
 }
 
+// Gap is a free data retrieval call binding the contract method 0xdab3b3da.
+//
+// Solidity: function _gap(uint256 ) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) Gap(opts *bind.CallOpts, arg0 *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "_gap", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Gap is a free data retrieval call binding the contract method 0xdab3b3da.
+//
+// Solidity: function _gap(uint256 ) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) Gap(arg0 *big.Int) (*big.Int, error) {
+	return _GasPriceOracle.Contract.Gap(&_GasPriceOracle.CallOpts, arg0)
+}
+
+// Gap is a free data retrieval call binding the contract method 0xdab3b3da.
+//
+// Solidity: function _gap(uint256 ) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) Gap(arg0 *big.Int) (*big.Int, error) {
+	return _GasPriceOracle.Contract.Gap(&_GasPriceOracle.CallOpts, arg0)
+}
+
 // BaseFee is a free data retrieval call binding the contract method 0x6ef25c3a.
 //
 // Solidity: function baseFee() view returns(uint256)
@@ -388,6 +419,68 @@ func (_GasPriceOracle *GasPriceOracleCallerSession) GetL1GasUsed(_data []byte) (
 	return _GasPriceOracle.Contract.GetL1GasUsed(&_GasPriceOracle.CallOpts, _data)
 }
 
+// GetOperatorFee is a free data retrieval call binding the contract method 0x275aedd2.
+//
+// Solidity: function getOperatorFee(uint256 _gasUsed) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) GetOperatorFee(opts *bind.CallOpts, _gasUsed *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "getOperatorFee", _gasUsed)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetOperatorFee is a free data retrieval call binding the contract method 0x275aedd2.
+//
+// Solidity: function getOperatorFee(uint256 _gasUsed) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) GetOperatorFee(_gasUsed *big.Int) (*big.Int, error) {
+	return _GasPriceOracle.Contract.GetOperatorFee(&_GasPriceOracle.CallOpts, _gasUsed)
+}
+
+// GetOperatorFee is a free data retrieval call binding the contract method 0x275aedd2.
+//
+// Solidity: function getOperatorFee(uint256 _gasUsed) view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) GetOperatorFee(_gasUsed *big.Int) (*big.Int, error) {
+	return _GasPriceOracle.Contract.GetOperatorFee(&_GasPriceOracle.CallOpts, _gasUsed)
+}
+
+// IsSkadi is a free data retrieval call binding the contract method 0x56976658.
+//
+// Solidity: function isSkadi() view returns(bool)
+func (_GasPriceOracle *GasPriceOracleCaller) IsSkadi(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "isSkadi")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsSkadi is a free data retrieval call binding the contract method 0x56976658.
+//
+// Solidity: function isSkadi() view returns(bool)
+func (_GasPriceOracle *GasPriceOracleSession) IsSkadi() (bool, error) {
+	return _GasPriceOracle.Contract.IsSkadi(&_GasPriceOracle.CallOpts)
+}
+
+// IsSkadi is a free data retrieval call binding the contract method 0x56976658.
+//
+// Solidity: function isSkadi() view returns(bool)
+func (_GasPriceOracle *GasPriceOracleCallerSession) IsSkadi() (bool, error) {
+	return _GasPriceOracle.Contract.IsSkadi(&_GasPriceOracle.CallOpts)
+}
+
 // L1BaseFee is a free data retrieval call binding the contract method 0x519b4bd3.
 //
 // Solidity: function l1BaseFee() view returns(uint256)
@@ -448,6 +541,68 @@ func (_GasPriceOracle *GasPriceOracleSession) Operator() (common.Address, error)
 // Solidity: function operator() view returns(address)
 func (_GasPriceOracle *GasPriceOracleCallerSession) Operator() (common.Address, error) {
 	return _GasPriceOracle.Contract.Operator(&_GasPriceOracle.CallOpts)
+}
+
+// OperatorFeeConstant is a free data retrieval call binding the contract method 0x16d3bc7f.
+//
+// Solidity: function operatorFeeConstant() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) OperatorFeeConstant(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "operatorFeeConstant")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// OperatorFeeConstant is a free data retrieval call binding the contract method 0x16d3bc7f.
+//
+// Solidity: function operatorFeeConstant() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) OperatorFeeConstant() (*big.Int, error) {
+	return _GasPriceOracle.Contract.OperatorFeeConstant(&_GasPriceOracle.CallOpts)
+}
+
+// OperatorFeeConstant is a free data retrieval call binding the contract method 0x16d3bc7f.
+//
+// Solidity: function operatorFeeConstant() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) OperatorFeeConstant() (*big.Int, error) {
+	return _GasPriceOracle.Contract.OperatorFeeConstant(&_GasPriceOracle.CallOpts)
+}
+
+// OperatorFeeScalar is a free data retrieval call binding the contract method 0x4d5d9a2a.
+//
+// Solidity: function operatorFeeScalar() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCaller) OperatorFeeScalar(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GasPriceOracle.contract.Call(opts, &out, "operatorFeeScalar")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// OperatorFeeScalar is a free data retrieval call binding the contract method 0x4d5d9a2a.
+//
+// Solidity: function operatorFeeScalar() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleSession) OperatorFeeScalar() (*big.Int, error) {
+	return _GasPriceOracle.Contract.OperatorFeeScalar(&_GasPriceOracle.CallOpts)
+}
+
+// OperatorFeeScalar is a free data retrieval call binding the contract method 0x4d5d9a2a.
+//
+// Solidity: function operatorFeeScalar() view returns(uint256)
+func (_GasPriceOracle *GasPriceOracleCallerSession) OperatorFeeScalar() (*big.Int, error) {
+	return _GasPriceOracle.Contract.OperatorFeeScalar(&_GasPriceOracle.CallOpts)
 }
 
 // Overhead is a free data retrieval call binding the contract method 0x0c18c162.
@@ -605,6 +760,27 @@ func (_GasPriceOracle *GasPriceOracleCallerSession) Version() (string, error) {
 	return _GasPriceOracle.Contract.Version(&_GasPriceOracle.CallOpts)
 }
 
+// SetIsSkadi is a paid mutator transaction binding the contract method 0x2312b618.
+//
+// Solidity: function setIsSkadi() returns()
+func (_GasPriceOracle *GasPriceOracleTransactor) SetIsSkadi(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GasPriceOracle.contract.Transact(opts, "setIsSkadi")
+}
+
+// SetIsSkadi is a paid mutator transaction binding the contract method 0x2312b618.
+//
+// Solidity: function setIsSkadi() returns()
+func (_GasPriceOracle *GasPriceOracleSession) SetIsSkadi() (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetIsSkadi(&_GasPriceOracle.TransactOpts)
+}
+
+// SetIsSkadi is a paid mutator transaction binding the contract method 0x2312b618.
+//
+// Solidity: function setIsSkadi() returns()
+func (_GasPriceOracle *GasPriceOracleTransactorSession) SetIsSkadi() (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetIsSkadi(&_GasPriceOracle.TransactOpts)
+}
+
 // SetOperator is a paid mutator transaction binding the contract method 0xb3ab15fb.
 //
 // Solidity: function setOperator(address _operator) returns()
@@ -624,6 +800,48 @@ func (_GasPriceOracle *GasPriceOracleSession) SetOperator(_operator common.Addre
 // Solidity: function setOperator(address _operator) returns()
 func (_GasPriceOracle *GasPriceOracleTransactorSession) SetOperator(_operator common.Address) (*types.Transaction, error) {
 	return _GasPriceOracle.Contract.SetOperator(&_GasPriceOracle.TransactOpts, _operator)
+}
+
+// SetOperatorFeeConstant is a paid mutator transaction binding the contract method 0x32e70fea.
+//
+// Solidity: function setOperatorFeeConstant(uint256 _operatorFeeConstant) returns()
+func (_GasPriceOracle *GasPriceOracleTransactor) SetOperatorFeeConstant(opts *bind.TransactOpts, _operatorFeeConstant *big.Int) (*types.Transaction, error) {
+	return _GasPriceOracle.contract.Transact(opts, "setOperatorFeeConstant", _operatorFeeConstant)
+}
+
+// SetOperatorFeeConstant is a paid mutator transaction binding the contract method 0x32e70fea.
+//
+// Solidity: function setOperatorFeeConstant(uint256 _operatorFeeConstant) returns()
+func (_GasPriceOracle *GasPriceOracleSession) SetOperatorFeeConstant(_operatorFeeConstant *big.Int) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetOperatorFeeConstant(&_GasPriceOracle.TransactOpts, _operatorFeeConstant)
+}
+
+// SetOperatorFeeConstant is a paid mutator transaction binding the contract method 0x32e70fea.
+//
+// Solidity: function setOperatorFeeConstant(uint256 _operatorFeeConstant) returns()
+func (_GasPriceOracle *GasPriceOracleTransactorSession) SetOperatorFeeConstant(_operatorFeeConstant *big.Int) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetOperatorFeeConstant(&_GasPriceOracle.TransactOpts, _operatorFeeConstant)
+}
+
+// SetOperatorFeeScalar is a paid mutator transaction binding the contract method 0x5d71ff8f.
+//
+// Solidity: function setOperatorFeeScalar(uint256 _operatorFeeScalar) returns()
+func (_GasPriceOracle *GasPriceOracleTransactor) SetOperatorFeeScalar(opts *bind.TransactOpts, _operatorFeeScalar *big.Int) (*types.Transaction, error) {
+	return _GasPriceOracle.contract.Transact(opts, "setOperatorFeeScalar", _operatorFeeScalar)
+}
+
+// SetOperatorFeeScalar is a paid mutator transaction binding the contract method 0x5d71ff8f.
+//
+// Solidity: function setOperatorFeeScalar(uint256 _operatorFeeScalar) returns()
+func (_GasPriceOracle *GasPriceOracleSession) SetOperatorFeeScalar(_operatorFeeScalar *big.Int) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetOperatorFeeScalar(&_GasPriceOracle.TransactOpts, _operatorFeeScalar)
+}
+
+// SetOperatorFeeScalar is a paid mutator transaction binding the contract method 0x5d71ff8f.
+//
+// Solidity: function setOperatorFeeScalar(uint256 _operatorFeeScalar) returns()
+func (_GasPriceOracle *GasPriceOracleTransactorSession) SetOperatorFeeScalar(_operatorFeeScalar *big.Int) (*types.Transaction, error) {
+	return _GasPriceOracle.Contract.SetOperatorFeeScalar(&_GasPriceOracle.TransactOpts, _operatorFeeScalar)
 }
 
 // SetTokenRatio is a paid mutator transaction binding the contract method 0xe38e91f9.
@@ -666,6 +884,312 @@ func (_GasPriceOracle *GasPriceOracleSession) TransferOwnership(_owner common.Ad
 // Solidity: function transferOwnership(address _owner) returns()
 func (_GasPriceOracle *GasPriceOracleTransactorSession) TransferOwnership(_owner common.Address) (*types.Transaction, error) {
 	return _GasPriceOracle.Contract.TransferOwnership(&_GasPriceOracle.TransactOpts, _owner)
+}
+
+// GasPriceOracleOperatorFeeConstantUpdatedIterator is returned from FilterOperatorFeeConstantUpdated and is used to iterate over the raw logs and unpacked data for OperatorFeeConstantUpdated events raised by the GasPriceOracle contract.
+type GasPriceOracleOperatorFeeConstantUpdatedIterator struct {
+	Event *GasPriceOracleOperatorFeeConstantUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GasPriceOracleOperatorFeeConstantUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GasPriceOracleOperatorFeeConstantUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GasPriceOracleOperatorFeeConstantUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GasPriceOracleOperatorFeeConstantUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GasPriceOracleOperatorFeeConstantUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GasPriceOracleOperatorFeeConstantUpdated represents a OperatorFeeConstantUpdated event raised by the GasPriceOracle contract.
+type GasPriceOracleOperatorFeeConstantUpdated struct {
+	PreviousOperatorFeeConstant *big.Int
+	NewOperatorFeeConstant      *big.Int
+	Raw                         types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorFeeConstantUpdated is a free log retrieval operation binding the contract event 0x08a9bc8992a7c4fa053bafee70f234ebf754c491d16759a28adf47e3cd9375b9.
+//
+// Solidity: event OperatorFeeConstantUpdated(uint256 indexed previousOperatorFeeConstant, uint256 indexed newOperatorFeeConstant)
+func (_GasPriceOracle *GasPriceOracleFilterer) FilterOperatorFeeConstantUpdated(opts *bind.FilterOpts, previousOperatorFeeConstant []*big.Int, newOperatorFeeConstant []*big.Int) (*GasPriceOracleOperatorFeeConstantUpdatedIterator, error) {
+
+	var previousOperatorFeeConstantRule []interface{}
+	for _, previousOperatorFeeConstantItem := range previousOperatorFeeConstant {
+		previousOperatorFeeConstantRule = append(previousOperatorFeeConstantRule, previousOperatorFeeConstantItem)
+	}
+	var newOperatorFeeConstantRule []interface{}
+	for _, newOperatorFeeConstantItem := range newOperatorFeeConstant {
+		newOperatorFeeConstantRule = append(newOperatorFeeConstantRule, newOperatorFeeConstantItem)
+	}
+
+	logs, sub, err := _GasPriceOracle.contract.FilterLogs(opts, "OperatorFeeConstantUpdated", previousOperatorFeeConstantRule, newOperatorFeeConstantRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GasPriceOracleOperatorFeeConstantUpdatedIterator{contract: _GasPriceOracle.contract, event: "OperatorFeeConstantUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorFeeConstantUpdated is a free log subscription operation binding the contract event 0x08a9bc8992a7c4fa053bafee70f234ebf754c491d16759a28adf47e3cd9375b9.
+//
+// Solidity: event OperatorFeeConstantUpdated(uint256 indexed previousOperatorFeeConstant, uint256 indexed newOperatorFeeConstant)
+func (_GasPriceOracle *GasPriceOracleFilterer) WatchOperatorFeeConstantUpdated(opts *bind.WatchOpts, sink chan<- *GasPriceOracleOperatorFeeConstantUpdated, previousOperatorFeeConstant []*big.Int, newOperatorFeeConstant []*big.Int) (event.Subscription, error) {
+
+	var previousOperatorFeeConstantRule []interface{}
+	for _, previousOperatorFeeConstantItem := range previousOperatorFeeConstant {
+		previousOperatorFeeConstantRule = append(previousOperatorFeeConstantRule, previousOperatorFeeConstantItem)
+	}
+	var newOperatorFeeConstantRule []interface{}
+	for _, newOperatorFeeConstantItem := range newOperatorFeeConstant {
+		newOperatorFeeConstantRule = append(newOperatorFeeConstantRule, newOperatorFeeConstantItem)
+	}
+
+	logs, sub, err := _GasPriceOracle.contract.WatchLogs(opts, "OperatorFeeConstantUpdated", previousOperatorFeeConstantRule, newOperatorFeeConstantRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GasPriceOracleOperatorFeeConstantUpdated)
+				if err := _GasPriceOracle.contract.UnpackLog(event, "OperatorFeeConstantUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorFeeConstantUpdated is a log parse operation binding the contract event 0x08a9bc8992a7c4fa053bafee70f234ebf754c491d16759a28adf47e3cd9375b9.
+//
+// Solidity: event OperatorFeeConstantUpdated(uint256 indexed previousOperatorFeeConstant, uint256 indexed newOperatorFeeConstant)
+func (_GasPriceOracle *GasPriceOracleFilterer) ParseOperatorFeeConstantUpdated(log types.Log) (*GasPriceOracleOperatorFeeConstantUpdated, error) {
+	event := new(GasPriceOracleOperatorFeeConstantUpdated)
+	if err := _GasPriceOracle.contract.UnpackLog(event, "OperatorFeeConstantUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GasPriceOracleOperatorFeeScalarUpdatedIterator is returned from FilterOperatorFeeScalarUpdated and is used to iterate over the raw logs and unpacked data for OperatorFeeScalarUpdated events raised by the GasPriceOracle contract.
+type GasPriceOracleOperatorFeeScalarUpdatedIterator struct {
+	Event *GasPriceOracleOperatorFeeScalarUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GasPriceOracleOperatorFeeScalarUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GasPriceOracleOperatorFeeScalarUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GasPriceOracleOperatorFeeScalarUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GasPriceOracleOperatorFeeScalarUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GasPriceOracleOperatorFeeScalarUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GasPriceOracleOperatorFeeScalarUpdated represents a OperatorFeeScalarUpdated event raised by the GasPriceOracle contract.
+type GasPriceOracleOperatorFeeScalarUpdated struct {
+	PreviousOperatorFeeScalar *big.Int
+	NewOperatorFeeScalar      *big.Int
+	Raw                       types.Log // Blockchain specific contextual infos
+}
+
+// FilterOperatorFeeScalarUpdated is a free log retrieval operation binding the contract event 0x977ba0b597123a7c26f0d57b10b1ab88e14d4e8676e6629640df681ccf5ffcf2.
+//
+// Solidity: event OperatorFeeScalarUpdated(uint256 indexed previousOperatorFeeScalar, uint256 indexed newOperatorFeeScalar)
+func (_GasPriceOracle *GasPriceOracleFilterer) FilterOperatorFeeScalarUpdated(opts *bind.FilterOpts, previousOperatorFeeScalar []*big.Int, newOperatorFeeScalar []*big.Int) (*GasPriceOracleOperatorFeeScalarUpdatedIterator, error) {
+
+	var previousOperatorFeeScalarRule []interface{}
+	for _, previousOperatorFeeScalarItem := range previousOperatorFeeScalar {
+		previousOperatorFeeScalarRule = append(previousOperatorFeeScalarRule, previousOperatorFeeScalarItem)
+	}
+	var newOperatorFeeScalarRule []interface{}
+	for _, newOperatorFeeScalarItem := range newOperatorFeeScalar {
+		newOperatorFeeScalarRule = append(newOperatorFeeScalarRule, newOperatorFeeScalarItem)
+	}
+
+	logs, sub, err := _GasPriceOracle.contract.FilterLogs(opts, "OperatorFeeScalarUpdated", previousOperatorFeeScalarRule, newOperatorFeeScalarRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GasPriceOracleOperatorFeeScalarUpdatedIterator{contract: _GasPriceOracle.contract, event: "OperatorFeeScalarUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchOperatorFeeScalarUpdated is a free log subscription operation binding the contract event 0x977ba0b597123a7c26f0d57b10b1ab88e14d4e8676e6629640df681ccf5ffcf2.
+//
+// Solidity: event OperatorFeeScalarUpdated(uint256 indexed previousOperatorFeeScalar, uint256 indexed newOperatorFeeScalar)
+func (_GasPriceOracle *GasPriceOracleFilterer) WatchOperatorFeeScalarUpdated(opts *bind.WatchOpts, sink chan<- *GasPriceOracleOperatorFeeScalarUpdated, previousOperatorFeeScalar []*big.Int, newOperatorFeeScalar []*big.Int) (event.Subscription, error) {
+
+	var previousOperatorFeeScalarRule []interface{}
+	for _, previousOperatorFeeScalarItem := range previousOperatorFeeScalar {
+		previousOperatorFeeScalarRule = append(previousOperatorFeeScalarRule, previousOperatorFeeScalarItem)
+	}
+	var newOperatorFeeScalarRule []interface{}
+	for _, newOperatorFeeScalarItem := range newOperatorFeeScalar {
+		newOperatorFeeScalarRule = append(newOperatorFeeScalarRule, newOperatorFeeScalarItem)
+	}
+
+	logs, sub, err := _GasPriceOracle.contract.WatchLogs(opts, "OperatorFeeScalarUpdated", previousOperatorFeeScalarRule, newOperatorFeeScalarRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GasPriceOracleOperatorFeeScalarUpdated)
+				if err := _GasPriceOracle.contract.UnpackLog(event, "OperatorFeeScalarUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOperatorFeeScalarUpdated is a log parse operation binding the contract event 0x977ba0b597123a7c26f0d57b10b1ab88e14d4e8676e6629640df681ccf5ffcf2.
+//
+// Solidity: event OperatorFeeScalarUpdated(uint256 indexed previousOperatorFeeScalar, uint256 indexed newOperatorFeeScalar)
+func (_GasPriceOracle *GasPriceOracleFilterer) ParseOperatorFeeScalarUpdated(log types.Log) (*GasPriceOracleOperatorFeeScalarUpdated, error) {
+	event := new(GasPriceOracleOperatorFeeScalarUpdated)
+	if err := _GasPriceOracle.contract.UnpackLog(event, "OperatorFeeScalarUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
 }
 
 // GasPriceOracleOperatorUpdatedIterator is returned from FilterOperatorUpdated and is used to iterate over the raw logs and unpacked data for OperatorUpdated events raised by the GasPriceOracle contract.

--- a/gas-oracle/flags/flags.go
+++ b/gas-oracle/flags/flags.go
@@ -127,6 +127,36 @@ var (
 		Usage:  "the creden of hsm key",
 		EnvVar: "GAS_PRICE_ORACLE_HSM_CREDEN",
 	}
+	OperatorFeeUpdateIntervalFlag = cli.Uint64Flag{
+		Name:   "operator-fee-update-interval",
+		Usage:  "the interval of updating the operator fee",
+		EnvVar: "GAS_PRICE_ORACLE_OPERATOR_FEE_UPDATE_INTERVAL",
+	}
+	OperatorFeeSignificanceFactorFlag = cli.Float64Flag{
+		Name:   "operator-fee-significance-factor",
+		Usage:  "the significance factor of updating the operator fee",
+		EnvVar: "GAS_PRICE_ORACLE_OPERATOR_FEE_SIGNIFICANCE_FACTOR",
+	}
+	IntrinsicSp1GasPerTxFlag = cli.Uint64Flag{
+		Name:   "intrinsic-sp1-gas-per-tx",
+		Usage:  "the intrinsic sp1 gas per tx",
+		EnvVar: "GAS_PRICE_ORACLE_INTRINSIC_SP1_GAS_PER_TX",
+	}
+	IntrinsicSp1GasPerBlockFlag = cli.Uint64Flag{
+		Name:   "intrinsic-sp1-gas-per-block",
+		Usage:  "the intrinsic sp1 gas per block",
+		EnvVar: "GAS_PRICE_ORACLE_INTRINSIC_SP1_GAS_PER_BLOCK",
+	}
+	Sp1PricePerBGasInDollarsFlag = cli.Float64Flag{
+		Name:   "sp1-price-per-bgas-in-dollars",
+		Usage:  "the price of sp1 per bgas in dollars",
+		EnvVar: "GAS_PRICE_ORACLE_SP1_PRICE_PER_BGAS_IN_DOLLARS",
+	}
+	BlockscoutExplorerURLFlag = cli.StringFlag{
+		Name:   "blockscout-explorer-url",
+		Usage:  "the url of the blockscout explorer",
+		EnvVar: "GAS_PRICE_ORACLE_BLOCKSCOUT_EXPLORER_URL",
+	}
 )
 
 var Flags = []cli.Flag{
@@ -152,4 +182,10 @@ var Flags = []cli.Flag{
 	MetricsEnabledFlag,
 	MetricsHTTPFlag,
 	MetricsPortFlag,
+	OperatorFeeUpdateIntervalFlag,
+	OperatorFeeSignificanceFactorFlag,
+	IntrinsicSp1GasPerTxFlag,
+	IntrinsicSp1GasPerBlockFlag,
+	Sp1PricePerBGasInDollarsFlag,
+	BlockscoutExplorerURLFlag,
 }

--- a/gas-oracle/metrics/metrics.go
+++ b/gas-oracle/metrics/metrics.go
@@ -19,6 +19,8 @@ var (
 		FeeScalarGauge metrics.Gauge
 		// L1GasPriceGauge l1_base_fee + l1_priority_fee
 		L1GasPriceGauge metrics.Gauge
+		// OperatorFeeConstantGauge
+		OperatorFeeConstantGauge metrics.Gauge
 	}
 )
 
@@ -31,4 +33,5 @@ func InitAndRegisterStats(r metrics.Registry) {
 	GasOracleStats.L1BaseFeeGauge = metrics.NewRegisteredGauge("l1_base_fee", r)
 	GasOracleStats.FeeScalarGauge = metrics.NewRegisteredGauge("fee_scalar", r)
 	GasOracleStats.L1GasPriceGauge = metrics.NewRegisteredGauge("l1_gas_price", r)
+	GasOracleStats.OperatorFeeConstantGauge = metrics.NewRegisteredGauge("operator_fee_constant", r)
 }

--- a/gas-oracle/metrics/metrics_test.go
+++ b/gas-oracle/metrics/metrics_test.go
@@ -20,4 +20,8 @@ func TestInitAndRegisterStats(t *testing.T) {
 	GasOracleStats.FeeScalarGauge.Update(1500000)
 	feeScalar := GasOracleStats.FeeScalarGauge.Value()
 	require.Equal(t, int64(1500000), feeScalar)
+
+	GasOracleStats.OperatorFeeConstantGauge.Update(1000000000)
+	operatorFeeConstant := GasOracleStats.OperatorFeeConstantGauge.Value()
+	require.Equal(t, int64(1000000000), operatorFeeConstant)
 }

--- a/gas-oracle/oracle/auth.go
+++ b/gas-oracle/oracle/auth.go
@@ -1,0 +1,113 @@
+package oracle
+
+import (
+	"context"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	bsscore "github.com/ethereum-optimism/optimism/bss-core"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"google.golang.org/api/option"
+)
+
+const gasPriceUpdateInterval = 5 * time.Minute
+
+type Auth struct {
+	mu sync.RWMutex
+
+	client *ethclient.Client
+	auth   *bind.TransactOpts
+
+	fixedGasPrice bool
+	lastUpdated   time.Time
+}
+
+func NewAuth(cfg *Config, client *ethclient.Client) (*Auth, error) {
+	var opts *bind.TransactOpts
+	var err error
+	if !cfg.EnableHsm {
+		if cfg.privateKey == nil {
+			return nil, errNoPrivateKey
+		}
+		if cfg.l2ChainID == nil {
+			return nil, errNoChainID
+		}
+
+		opts, err = bind.NewKeyedTransactorWithChainID(cfg.privateKey, cfg.l2ChainID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		seqBytes, err := hex.DecodeString(cfg.HsmCreden)
+		if err != nil {
+			log.Warn("gasoracle/auth", "decode hsm creden fail", err.Error())
+			return nil, err
+		}
+		apikey := option.WithCredentialsJSON(seqBytes)
+		client, err := kms.NewKeyManagementClient(context.Background(), apikey)
+		if err != nil {
+			log.Warn("gasoracle/auth", "create signer error", err.Error())
+			return nil, err
+		}
+		mk := &bsscore.ManagedKey{
+			KeyName:      cfg.HsmAPIName,
+			EthereumAddr: common.HexToAddress(cfg.HsmAddress),
+			Gclient:      client,
+		}
+		opts, err = mk.NewEthereumTransactorWithChainID(context.Background(), cfg.l2ChainID)
+		if err != nil {
+			log.Warn("gasoracle/auth", "create signer error", err.Error())
+			return nil, err
+		}
+	}
+	// Once https://github.com/ethereum/go-ethereum/pull/23062 is released
+	// then we can remove setting the context here
+	if opts.Context == nil {
+		opts.Context = context.Background()
+	}
+
+	fixedGasPrice := false
+
+	// Use the configured gas price if it is set,
+	// otherwise use gas estimation
+	if cfg.gasPrice != nil {
+		fixedGasPrice = true
+		opts.GasPrice = cfg.gasPrice
+	} else {
+		gasPrice, err := client.SuggestGasPrice(opts.Context)
+		if err != nil {
+			return nil, err
+		}
+		opts.GasPrice = gasPrice
+	}
+
+	return &Auth{
+		client:        client,
+		auth:          opts,
+		fixedGasPrice: fixedGasPrice,
+		lastUpdated:   time.Now(),
+	}, nil
+}
+
+func (a *Auth) Opts() *bind.TransactOpts {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Update gas price if needed
+	if !a.fixedGasPrice && time.Since(a.lastUpdated) >= gasPriceUpdateInterval {
+		gasPrice, err := a.client.SuggestGasPrice(a.auth.Context)
+		if err != nil {
+			log.Error("gasoracle/auth", "update gas price error", err.Error())
+		} else {
+			a.auth.GasPrice = gasPrice
+			a.lastUpdated = time.Now()
+		}
+	}
+
+	return a.auth
+}

--- a/gas-oracle/oracle/config.go
+++ b/gas-oracle/oracle/config.go
@@ -39,6 +39,14 @@ type Config struct {
 	MetricsEnabled bool
 	MetricsHTTP    string
 	MetricsPort    int
+	// operator fee config
+	OperatorFeeUpdateInterval     uint64
+	OperatorFeeSignificanceFactor float64
+	IntrinsicSp1GasPerTx          uint64
+	IntrinsicSp1GasPerBlock       uint64
+	Sp1PricePerBGasInDollars      float64
+	// mantle explorer config
+	BlockscoutExplorerURL string
 }
 
 // NewConfig creates a new Config
@@ -97,6 +105,16 @@ func NewConfig(ctx *cli.Context) *Config {
 	cfg.MetricsEnabled = ctx.GlobalBool(flags.MetricsEnabledFlag.Name)
 	cfg.MetricsHTTP = ctx.GlobalString(flags.MetricsHTTPFlag.Name)
 	cfg.MetricsPort = ctx.GlobalInt(flags.MetricsPortFlag.Name)
+
+	cfg.OperatorFeeUpdateInterval = ctx.GlobalUint64(flags.OperatorFeeUpdateIntervalFlag.Name)
+	if cfg.OperatorFeeUpdateInterval > 0 {
+		cfg.OperatorFeeSignificanceFactor = ctx.GlobalFloat64(flags.OperatorFeeSignificanceFactorFlag.Name)
+		cfg.IntrinsicSp1GasPerTx = ctx.GlobalUint64(flags.IntrinsicSp1GasPerTxFlag.Name)
+		cfg.IntrinsicSp1GasPerBlock = ctx.GlobalUint64(flags.IntrinsicSp1GasPerBlockFlag.Name)
+		cfg.Sp1PricePerBGasInDollars = ctx.GlobalFloat64(flags.Sp1PricePerBGasInDollarsFlag.Name)
+	}
+
+	cfg.BlockscoutExplorerURL = ctx.GlobalString(flags.BlockscoutExplorerURLFlag.Name)
 
 	return &cfg
 }

--- a/gas-oracle/oracle/explorer_client.go
+++ b/gas-oracle/oracle/explorer_client.go
@@ -1,0 +1,95 @@
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	DefaultBlockscoutExplorerURL = "https://explorer.mantle.xyz"
+	StatsAPIHandler              = "/api/v2/stats"
+	DailyBlockCount              = 43200
+)
+
+// ExplorerStats represents the response from the Mantle explorer stats API
+type ExplorerStats struct {
+	TransactionsToday string `json:"transactions_today"`
+}
+
+// ExplorerClient provides access to Mantle explorer APIs
+type ExplorerClient struct {
+	client  *http.Client
+	baseURL string
+}
+
+// NewExplorerClient creates a new explorer client
+func NewExplorerClient(baseURL string) *ExplorerClient {
+	if baseURL == "" {
+		baseURL = DefaultBlockscoutExplorerURL
+	}
+	return &ExplorerClient{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		baseURL: baseURL,
+	}
+}
+
+// DailyTxCount fetches the daily transaction count from the Mantle explorer API
+func (e *ExplorerClient) DailyTxCount(ctx context.Context) (uint64, error) {
+	apiURL, err := url.JoinPath(e.baseURL, StatsAPIHandler)
+	if err != nil {
+		return 0, fmt.Errorf("failed to construct API URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("accept", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch transaction count: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("API request failed with status: %d", resp.StatusCode)
+	}
+
+	var stats ExplorerStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	txCount, err := strconv.ParseUint(stats.TransactionsToday, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse transaction count: %w", err)
+	}
+
+	log.Debug("Fetched daily transaction count", "count", txCount, "url", apiURL)
+
+	return txCount, nil
+}
+
+func (e *ExplorerClient) DailyTxCountFromUser(ctx context.Context) (uint64, error) {
+	txCount, err := e.DailyTxCount(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	if txCount <= DailyBlockCount {
+		return 0, fmt.Errorf("transaction count is less than daily block count")
+	}
+
+	return txCount - DailyBlockCount, nil
+}

--- a/gas-oracle/oracle/explorer_client_test.go
+++ b/gas-oracle/oracle/explorer_client_test.go
@@ -1,0 +1,48 @@
+package oracle
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewExplorerClient(t *testing.T) {
+	client := NewExplorerClient("")
+	if client == nil {
+		t.Fatal("NewExplorerClient() returned nil")
+	}
+	if client.client == nil {
+		t.Error("ExplorerClient client is nil")
+	}
+	if client.baseURL != DefaultBlockscoutExplorerURL {
+		t.Errorf("Expected baseURL %s, got %s", DefaultBlockscoutExplorerURL, client.baseURL)
+	}
+}
+
+func TestNewExplorerClientWithCustomURL(t *testing.T) {
+	customURL := "https://custom-explorer.com"
+	client := NewExplorerClient(customURL)
+	if client == nil {
+		t.Fatal("NewExplorerClient() returned nil")
+	}
+	if client.baseURL != customURL {
+		t.Errorf("Expected baseURL %s, got %s", customURL, client.baseURL)
+	}
+}
+
+func TestExplorerClientDailyTxCount(t *testing.T) {
+	client := NewExplorerClient("")
+
+	// Test the actual API call
+	txCount, err := client.DailyTxCount(context.Background())
+	if err != nil {
+		t.Logf("DailyTxCount() returned error (this might be expected if API is not available): %v", err)
+		// Don't fail the test if the API is not available
+		return
+	}
+
+	if txCount == 0 {
+		t.Log("DailyTxCount() returned 0 (this might be expected)")
+	} else {
+		t.Logf("DailyTxCount() returned: %d", txCount)
+	}
+}

--- a/gas-oracle/oracle/operator_fee.go
+++ b/gas-oracle/oracle/operator_fee.go
@@ -1,0 +1,156 @@
+package oracle
+
+import (
+	"fmt"
+	"math/big"
+
+	ometrics "github.com/ethereum-optimism/optimism/gas-oracle/metrics"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	// Constants for the new operator fee formula
+	DefaultIntrinsicSp1GasPerTx     = uint64(3e6)
+	DefaultIntrinsicSp1GasPerBlock  = uint64(15e6)
+	OperatorFeeUpdateThreshold      = 0.05 // 5% threshold
+	DefaultSp1PricePerBGasInDollars = 0.58
+)
+
+// OperatorFeeCalculator is a function type that calculates the operator fee constant
+// based on txCount and ETH price
+type OperatorFeeCalculator func(txCount uint64, ethPrice float64) (*big.Int, error)
+
+// NewOperatorFeeCalculator creates a new operator fee calculator function
+// Formula:
+//
+//	operatorFeeConstant =
+//		(intrinsicSp1GasPerTx + (intrinsicSp1GasPerBlock * 43200) / txCount) * (sp1PricePerBGasInDollars * 1e-9 / (ethPrice * 1e-18))
+func NewOperatorFeeCalculator(intrinsicSp1GasPerTx, intrinsicSp1GasPerBlock uint64, sp1PricePerBGasInDollars float64) OperatorFeeCalculator {
+	if intrinsicSp1GasPerTx == 0 {
+		intrinsicSp1GasPerTx = DefaultIntrinsicSp1GasPerTx
+		log.Info("Using default intrinsic sp1 gas per tx", "value", intrinsicSp1GasPerTx)
+	}
+	if intrinsicSp1GasPerBlock == 0 {
+		intrinsicSp1GasPerBlock = DefaultIntrinsicSp1GasPerBlock
+		log.Info("Using default intrinsic sp1 gas per block", "value", intrinsicSp1GasPerBlock)
+	}
+	if sp1PricePerBGasInDollars <= 0 {
+		sp1PricePerBGasInDollars = DefaultSp1PricePerBGasInDollars
+		log.Info("Using default sp1 price per bgas in dollars", "value", sp1PricePerBGasInDollars)
+	}
+
+	return func(txCount uint64, ethPrice float64) (*big.Int, error) {
+		if ethPrice <= 0 {
+			return nil, fmt.Errorf("ETH price is 0 or negative")
+		}
+		if txCount == 0 {
+			return nil, fmt.Errorf("transaction count is 0")
+		}
+
+		// Step 1: Calculate apportioned intrinsic sp1 gas of block
+		txCountFloat := new(big.Int).SetUint64(txCount)
+		sp1GasPerDay := new(big.Int).Mul(new(big.Int).SetUint64(intrinsicSp1GasPerBlock), new(big.Int).SetUint64(43200))
+		apportionedSp1GasPerTx := new(big.Int).Div(sp1GasPerDay, txCountFloat)
+
+		// Step 2: Calculate total sp1 gas used per tx
+		totalSp1GasPerTx := new(big.Int).Add(new(big.Int).SetUint64(intrinsicSp1GasPerTx), apportionedSp1GasPerTx)
+
+		// Step 3: Calculate sp1 price per gas in wei
+		sp1PricePerGasInWei := calSp1PricePerGasInWei(sp1PricePerBGasInDollars, ethPrice)
+
+		// Step 4: Calculate final result
+		result := new(big.Int).Mul(totalSp1GasPerTx, sp1PricePerGasInWei)
+
+		log.Info("Calculated operator fee constant",
+			"transaction_count", txCount,
+			"eth_price", ethPrice,
+			"operator_fee_constant", result.String())
+
+		return result, nil
+	}
+}
+
+// we assume that the Sp1PricePerGasInWei is always a positive and significant value
+// output big.Int instead of big.Float to have more human readable value
+// truncate to 1 if the result is too small
+func calSp1PricePerGasInWei(sp1PricePerBGasInDollars float64, ethPrice float64) *big.Int {
+	sp1PricePerGasInWei := new(big.Float).Quo(new(big.Float).SetFloat64(sp1PricePerBGasInDollars*1e9), new(big.Float).SetFloat64(ethPrice))
+	resultInt := new(big.Int)
+	sp1PricePerGasInWei.Int(resultInt)
+	if resultInt.Cmp(big.NewInt(0)) == 0 {
+		log.Warn("sp1PricePerGasInWei is too small, truncated to 1")
+		return big.NewInt(1)
+	}
+	return resultInt
+}
+
+// UpdateOperatorFeeConstant is the main function that orchestrates the operator fee update process
+func (g *GasPriceOracle) updateOperatorFeeConstant() error {
+	// Step 1: Get current ETH price from token ratio client
+	ethPrice := g.tokenRatio.EthPrice()
+
+	// Step 2: Fetch transaction count from the explorer client
+	// DailyTxCountFromUser is the transaction count from the explorer client minus the daily block count
+	txCount, err := g.explorerClient.DailyTxCountFromUser(g.ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch transaction count: %w", err)
+	}
+
+	// Step 3: Calculate new operator fee constant using the calculator function
+	newConstant, err := g.operatorFeeCalculator(txCount, ethPrice)
+	if err != nil {
+		return fmt.Errorf("failed to calculate operator fee constant: %w", err)
+	}
+
+	// Step 4: Get cached operator fee constant
+	currentConstant := g.lastOperatorFeeConstant
+
+	log.Debug("Getting cached operator fee constant", "cached_value", currentConstant.String())
+
+	// Step 5: Only update if the value has changed by more than the significance factor
+	significanceFactor := g.config.OperatorFeeSignificanceFactor
+	if significanceFactor <= 0 {
+		significanceFactor = OperatorFeeUpdateThreshold
+	}
+	if isDifferenceSignificant(currentConstant.Uint64(), newConstant.Uint64(), significanceFactor) {
+		log.Info("Updating operator fee constant - change exceeds threshold",
+			"current", currentConstant.String(),
+			"new", newConstant.String())
+
+		// Update the cache with the new value
+		g.lastOperatorFeeConstant = newConstant
+		return g.setOperatorFeeConstant(newConstant)
+	} else {
+		log.Debug("Operator fee constant unchanged or change is below threshold, skipping update",
+			"current_value", currentConstant.String())
+	}
+
+	return nil
+}
+
+// updateOperatorFeeConstantOnContract updates the operator fee constant on the smart contract
+func (g *GasPriceOracle) setOperatorFeeConstant(newConstant *big.Int) error {
+	// Send transaction to update operator fee constant
+	tx, err := g.contract.SetOperatorFeeConstant(g.auth.Opts(), newConstant)
+	if err != nil {
+		return fmt.Errorf("failed to update operator fee constant: %w", err)
+	}
+
+	log.Info("Operator fee constant update transaction sent",
+		"tx_hash", tx.Hash().Hex())
+	ometrics.GasOracleStats.OperatorFeeConstantGauge.Update(newConstant.Int64())
+
+	// Wait for receipt if configured
+	if g.config.waitForReceipt {
+		// Wait for the receipt
+		receipt, err := waitForReceipt(g.l2Backend, tx)
+		if err != nil {
+			return err
+		}
+		log.Info("Operator fee constant update transaction confirmed",
+			"tx_hash", tx.Hash().Hex(),
+			"block_number", receipt.BlockNumber)
+	}
+
+	return nil
+}

--- a/gas-oracle/oracle/operator_fee_test.go
+++ b/gas-oracle/oracle/operator_fee_test.go
@@ -1,0 +1,97 @@
+package oracle
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestCalculateOperatorFeeConstant(t *testing.T) {
+	calculator := NewOperatorFeeCalculator(DefaultIntrinsicSp1GasPerTx, DefaultIntrinsicSp1GasPerBlock, DefaultSp1PricePerBGasInDollars)
+
+	baseTxCount := uint64(200000)
+	baseEthPrice := 2500.0
+	baseConstant, _ := calculator(baseTxCount, baseEthPrice)
+	if baseConstant.Cmp(big.NewInt(1447680000000)) != 0 {
+		t.Errorf("baseConstant: %s, expected: %s", baseConstant.String(), "1447680000000")
+	}
+
+	tests := []struct {
+		name         string
+		txCount      uint64
+		ethPrice     float64
+		expectError  bool
+		expectedSign int
+	}{
+		{
+			name:         "zero ETH price",
+			txCount:      1000000,
+			ethPrice:     0.0,
+			expectError:  true,
+			expectedSign: 0,
+		},
+		{
+			name:         "negative ETH price",
+			txCount:      1000000,
+			ethPrice:     -100.0,
+			expectError:  true,
+			expectedSign: 0,
+		},
+		{
+			name:         "zero tx count",
+			txCount:      0,
+			ethPrice:     baseEthPrice,
+			expectError:  true,
+			expectedSign: 0,
+		},
+		{
+			name:         "ETH price x2",
+			txCount:      baseTxCount,
+			ethPrice:     2 * baseEthPrice,
+			expectError:  false,
+			expectedSign: -1,
+		},
+		{
+			name:         "ETH price x0.5",
+			txCount:      baseTxCount,
+			ethPrice:     0.5 * baseEthPrice,
+			expectError:  false,
+			expectedSign: 1,
+		},
+		{
+			name:         "Tx count x2",
+			txCount:      2 * baseTxCount,
+			ethPrice:     baseEthPrice,
+			expectError:  false,
+			expectedSign: -1,
+		},
+		{
+			name:         "Tx count x0.5",
+			txCount:      baseTxCount / 2,
+			ethPrice:     baseEthPrice,
+			expectError:  false,
+			expectedSign: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := calculator(tt.txCount, tt.ethPrice)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("calculateOperatorFeeConstant(%d,%f) expected error but got none",
+						tt.txCount, tt.ethPrice)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("calculateOperatorFeeConstant(%d,%f) unexpected error: %v",
+						tt.txCount, tt.ethPrice, err)
+				}
+				if tt.expectedSign != result.Cmp(baseConstant) {
+					t.Errorf("calculateOperatorFeeConstant(%d,%f) = %s, expected sign %d, baseConstant: %s",
+						tt.txCount, tt.ethPrice, result.String(), tt.expectedSign, baseConstant.String())
+				}
+			}
+		})
+	}
+}

--- a/gas-oracle/oracle/token_ratio.go
+++ b/gas-oracle/oracle/token_ratio.go
@@ -2,73 +2,21 @@ package oracle
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 
-	bsscore "github.com/ethereum-optimism/optimism/bss-core"
 	"github.com/ethereum-optimism/optimism/gas-oracle/bindings"
 	ometrics "github.com/ethereum-optimism/optimism/gas-oracle/metrics"
 	"github.com/ethereum-optimism/optimism/gas-oracle/tokenratio"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
-
-	kms "cloud.google.com/go/kms/apiv1"
-	"google.golang.org/api/option"
 )
 
-func wrapUpdateTokenRatio(l1Backend bind.ContractTransactor, l2Backend DeployContractBackend, tokenRatio *tokenratio.Client, cfg *Config) (func() error, error) {
+func wrapUpdateTokenRatio(l1Backend bind.ContractTransactor, l2Backend DeployContractBackend, tokenRatio *tokenratio.Client, cfg *Config, auth *Auth) (func() error, error) {
 	if cfg.l2ChainID == nil {
 		return nil, errNoChainID
 	}
-
-	var opts *bind.TransactOpts
-	var err error
-	if !cfg.EnableHsm {
-		if cfg.privateKey == nil {
-			return nil, errNoPrivateKey
-		}
-		if cfg.l2ChainID == nil {
-			return nil, errNoChainID
-		}
-
-		opts, err = bind.NewKeyedTransactorWithChainID(cfg.privateKey, cfg.l2ChainID)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		seqBytes, err := hex.DecodeString(cfg.HsmCreden)
-		if err != nil {
-			log.Warn("gasoracle", "decode hsm creden fail", err.Error())
-			return nil, err
-		}
-		apikey := option.WithCredentialsJSON(seqBytes)
-		client, err := kms.NewKeyManagementClient(context.Background(), apikey)
-		if err != nil {
-			log.Warn("gasoracle", "create signer error", err.Error())
-			return nil, err
-		}
-		mk := &bsscore.ManagedKey{
-			KeyName:      cfg.HsmAPIName,
-			EthereumAddr: common.HexToAddress(cfg.HsmAddress),
-			Gclient:      client,
-		}
-		opts, err = mk.NewEthereumTransactorWithChainID(context.Background(), cfg.l2ChainID)
-		if err != nil {
-			log.Warn("gasoracle", "create signer error", err.Error())
-			return nil, err
-		}
-	}
-	// Once https://github.com/ethereum/go-ethereum/pull/23062 is released
-	// then we can remove setting the context here
-	if opts.Context == nil {
-		opts.Context = context.Background()
-	}
-	// Don't send the transaction using the `contract` so that we can inspect
-	// it beforehand
-	opts.NoSend = true
 
 	// Create a new contract bindings in scope of the updateL2GasPriceFn
 	// that is returned from this function
@@ -119,27 +67,14 @@ func wrapUpdateTokenRatio(l1Backend bind.ContractTransactor, l2Backend DeployCon
 			return nil
 		}
 
-		// Use the configured gas price if it is set,
-		// otherwise use gas estimation
-		if cfg.gasPrice != nil {
-			opts.GasPrice = cfg.gasPrice
-		} else {
-			gasPrice, err := l2Backend.SuggestGasPrice(opts.Context)
-			if err != nil {
-				return err
-			}
-			opts.GasPrice = gasPrice
-		}
+		opts := auth.Opts()
 		// set L1BaseFee to base fee + tip cap, to cover rollup tip cap
 		tx, err := contract.SetTokenRatio(opts, big.NewInt(int64(latestRatio)))
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot update tokenRatio: %w", err)
 		}
 		log.Info("updating tokenRatio", "tx.gasPrice", tx.GasPrice(), "tx.gasLimit", tx.Gas(),
 			"tx.data", hexutil.Encode(tx.Data()), "tx.to", tx.To().Hex(), "tx.nonce", tx.Nonce())
-		if err := l2Backend.SendTransaction(context.Background(), tx); err != nil {
-			return fmt.Errorf("cannot update tokenRatio: %w", err)
-		}
 		log.Info("TokenRatio transaction already sent", "hash", tx.Hash().Hex(), "tokenRatio", int64(latestRatio))
 		ometrics.GasOracleStats.TokenRatioOnchainGauge.Update(latestRatio)
 

--- a/gas-oracle/tokenratio/tokenratio.go
+++ b/gas-oracle/tokenratio/tokenratio.go
@@ -118,6 +118,16 @@ func (c *Client) TokenRatio() float64 {
 	return c.latestRatio
 }
 
+// EthPrice returns the current ETH price in USD
+func (c *Client) EthPrice() float64 {
+	return c.lastEthPrice
+}
+
+// MNTPrice returns the current MNT price in USD
+func (c *Client) MNTPrice() float64 {
+	return c.lastMntPrice
+}
+
 func (c *Client) tokenRatio() (float64, error) {
 	// Todo query token prices concurrent
 	var mntPrices, ethPrices []float64

--- a/packages/contracts-bedrock/contracts/libraries/Arithmetic.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Arithmetic.sol
@@ -1,48 +1,55 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
+// Libraries
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import { FixedPointMathLib } from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 
-/**
- * @title Arithmetic
- * @notice Even more math than before.
- */
+/// @title Arithmetic
+/// @notice Even more math than before.
 library Arithmetic {
-    /**
-     * @notice Clamps a value between a minimum and maximum.
-     *
-     * @param _value The value to clamp.
-     * @param _min   The minimum value.
-     * @param _max   The maximum value.
-     *
-     * @return The clamped value.
-     */
-    function clamp(
-        int256 _value,
-        int256 _min,
-        int256 _max
-    ) internal pure returns (int256) {
+    /// @notice Clamps a value between a minimum and maximum.
+    /// @param _value The value to clamp.
+    /// @param _min   The minimum value.
+    /// @param _max   The maximum value.
+    /// @return The clamped value.
+    function clamp(int256 _value, int256 _min, int256 _max) internal pure returns (int256) {
         return SignedMath.min(SignedMath.max(_value, _min), _max);
     }
 
-    /**
-     * @notice (c)oefficient (d)enominator (exp)onentiation function.
-     *         Returns the result of: c * (1 - 1/d)^exp.
-     *
-     * @param _coefficient Coefficient of the function.
-     * @param _denominator Fractional denominator.
-     * @param _exponent    Power function exponent.
-     *
-     * @return Result of c * (1 - 1/d)^exp.
-     */
-    function cdexp(
-        int256 _coefficient,
-        int256 _denominator,
-        int256 _exponent
-    ) internal pure returns (int256) {
-        return
-            (_coefficient *
-                (FixedPointMathLib.powWad(1e18 - (1e18 / _denominator), _exponent * 1e18))) / 1e18;
+    /// @notice (c)oefficient (d)enominator (exp)onentiation function.
+    ///         Returns the result of: c * (1 - 1/d)^exp.
+    /// @param _coefficient Coefficient of the function.
+    /// @param _denominator Fractional denominator.
+    /// @param _exponent    Power function exponent.
+    /// @return Result of c * (1 - 1/d)^exp.
+    function cdexp(int256 _coefficient, int256 _denominator, int256 _exponent) internal pure returns (int256) {
+        return (_coefficient * (FixedPointMathLib.powWad(1e18 - (1e18 / _denominator), _exponent * 1e18))) / 1e18;
+    }
+
+    /// @notice Saturating addition.
+    /// @param _x The first value.
+    /// @param _y The second value.
+    /// @return z_ The sum of the two values, or the maximum value if the sum overflows.
+    /// @dev Returns `min(2 ** 256 - 1, x + y)`.
+    /// @dev Taken from Solady
+    /// https://github.com/Vectorized/solady/blob/63416d60c78aba70a12ca1b3c11125d1061caa12/src/utils/FixedPointMathLib.sol#L673
+    function saturatingAdd(uint256 _x, uint256 _y) internal pure returns (uint256 z_) {
+        assembly ("memory-safe") {
+            z_ := or(sub(0, lt(add(_x, _y), _x)), add(_x, _y))
+        }
+    }
+
+    /// @notice Saturating multiplication.
+    /// @param _x The first value.
+    /// @param _y The second value.
+    /// @return z_ The product of the two values, or the maximum value if the product overflows.
+    /// @dev Returns `min(2 ** 256 - 1, x * y).
+    /// @dev Taken from Solady
+    /// https://github.com/Vectorized/solady/blob/63416d60c78aba70a12ca1b3c11125d1061caa12/src/utils/FixedPointMathLib.sol#L681
+    function saturatingMul(uint256 _x, uint256 _y) internal pure returns (uint256 z_) {
+        assembly ("memory-safe") {
+            z_ := or(sub(or(iszero(_x), eq(div(mul(_x, _y), _x), _y)), 1), mul(_x, _y))
+        }
     }
 }

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -24,6 +24,12 @@ fs_permissions = [
   { 'access'='read-write', 'path'='./.resource-metering.csv' },
 ]
 
+[fmt]
+line_length=120
+multiline_func_header='all'
+bracket_spacing=true
+wrap_comments=true
+
 [profile.ci]
 fuzz_runs = 512
 


### PR DESCRIPTION
contracts:

- new operator fee constant and operato fee scalar
- new bool flag `IsSkadi` to control whether enable operator fee or not

gas-oracle:

- introduce a reused tx signer for both token ratio update and operator fee update
- new loop for calculating and updating operator fee
- create an explorer client for fetching daily tx count
- open 2 new apis on token ratio client for getting current `ETH` and `MNT` prices 