### PR TITLE
chore(deploy): add explicit gasLimit in deploy-utils for SystemDictator steps 019-021

### DIFF
--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -121,6 +121,7 @@ const deployFn: DeployFunction = async (hre) => {
   if (
     (await SystemDictatorProxy.callStatic.implementation({
       from: ethers.constants.AddressZero,
+      gasLimit: 15000000,
     })) !== SystemDictatorImpl.address
   ) {
     console.log('Upgrading the SystemDictator proxy...')
@@ -138,6 +139,7 @@ const deployFn: DeployFunction = async (hre) => {
         return (
           (await SystemDictatorProxy.callStatic.implementation({
             from: ethers.constants.AddressZero,
+            gasLimit: 15000000,
           })) === SystemDictatorImpl.address
         )
       },
@@ -182,6 +184,7 @@ const deployFn: DeployFunction = async (hre) => {
   if (
     (await SystemDictatorProxy.callStatic.admin({
       from: ethers.constants.AddressZero,
+      gasLimit: 15000000,
     })) !== hre.deployConfig.controller
   ) {
     console.log('Transferring ownership of the SystemDictator proxy...')
@@ -195,6 +198,7 @@ const deployFn: DeployFunction = async (hre) => {
         return (
           (await SystemDictatorProxy.callStatic.admin({
             from: ethers.constants.AddressZero,
+            gasLimit: 15000000,
           })) === hre.deployConfig.controller
         )
       },

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -111,6 +111,7 @@ const deployFn: DeployFunction = async (hre) => {
     needsProxyTransfer &&
     (await L1StandardBridgeProxy.callStatic.getOwner({
       from: ethers.constants.AddressZero,
+      gasLimit: 15000000,
     })) !== SystemDictator.address
   ) {
     await doOwnershipTransfer({
@@ -129,6 +130,7 @@ const deployFn: DeployFunction = async (hre) => {
     needsProxyTransfer &&
     (await L1ERC721BridgeProxy.callStatic.admin({
       from: ethers.constants.AddressZero,
+      gasLimit: 15000000,
     })) !== SystemDictator.address
   ) {
     await doOwnershipTransfer({
@@ -150,9 +152,11 @@ const deployFn: DeployFunction = async (hre) => {
       const l1StandardBridgeOwner =
         await L1StandardBridgeProxy.callStatic.getOwner({
           from: ethers.constants.AddressZero,
+          gasLimit: 15000000,
         })
       const l1Erc721BridgeOwner = await L1ERC721BridgeProxy.callStatic.admin({
         from: ethers.constants.AddressZero,
+        gasLimit: 15000000,
       })
 
       return (

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -230,12 +230,14 @@ const deployFn: DeployFunction = async (hre) => {
       assert(
         (await L1StandardBridgeProxy.callStatic.getOwner({
           from: ethers.constants.AddressZero,
+          gasLimit: 15000000,
         })) === ProxyAdmin.address
       )
 
       assert(
         (await L1ERC721BridgeProxy.callStatic.admin({
           from: ProxyAdmin.address,
+          gasLimit: 15000000,
         })) === ProxyAdmin.address
       )
 

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -41,6 +41,7 @@ const config: HardhatUserConfig = {
       accounts: [
         'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
       ],
+      gas: 15000000,
     },
     devnetL2: {
       live: false,

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -142,6 +142,7 @@ export const asAdvancedContract = (opts: {
       // Now actually trigger the transaction (or call).
       const tx = await fn(...args, {
         gasPrice,
+        gasLimit: 15000000,
       })
 
       // Meant for static calls, we don't need to wait for anything, we get the result right away.
@@ -269,6 +270,7 @@ export const assertContractVariable = async (
 
   const actual = await temp.callStatic[variable]({
     from: ethers.constants.AddressZero,
+    gasLimit: 15000000,
   })
 
   if (ethers.utils.isAddress(expected)) {

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -63,6 +63,7 @@ export const deploy = async ({
       args,
       log: true,
       waitConfirmations: numDeployConfirmations,
+      gasLimit: 15000000,
     })
     console.log(`Deployed ${name} at ${result.address}`)
     // Only wait for the transaction if it was recently deployed in case the


### PR DESCRIPTION

- Prevent OOG errors by setting manual gasLimit (15_000_000)
- Updated hardhat.config.ts to align default gas settings
- Temporary fix, will refactor into common utility method