### PR TITLE
fix: backward compatibility with op-geth v1.4.0-rc0

### DIFF
--- a/gas-oracle/metrics/metrics_test.go
+++ b/gas-oracle/metrics/metrics_test.go
@@ -10,14 +10,14 @@ func TestInitAndRegisterStats(t *testing.T) {
 	InitAndRegisterStats(DefaultRegistry)
 
 	GasOracleStats.L1BaseFeeGauge.Update(100)
-	l1BaseFee := GasOracleStats.L1BaseFeeGauge.Value()
+	l1BaseFee := GasOracleStats.L1BaseFeeGauge.Snapshot().Value()
 	require.Equal(t, int64(100), l1BaseFee)
 
 	GasOracleStats.TokenRatioGauge.Update(4000)
-	tokenRatio := GasOracleStats.TokenRatioGauge.Value()
+	tokenRatio := GasOracleStats.TokenRatioGauge.Snapshot().Value()
 	require.Equal(t, float64(4000), tokenRatio)
 
 	GasOracleStats.FeeScalarGauge.Update(1500000)
-	feeScalar := GasOracleStats.FeeScalarGauge.Value()
+	feeScalar := GasOracleStats.FeeScalarGauge.Snapshot().Value()
 	require.Equal(t, int64(1500000), feeScalar)
 }

--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -249,7 +249,18 @@ func NewLogger(wr io.Writer, cfg CLIConfig) log.Logger {
 func SetGlobalLogHandler(h slog.Handler) {
 	l := log.NewLogger(h)
 	ctx := logfilter.AddLogAttrToContext(context.Background(), "global", true)
-	l.SetContext(ctx)
+
+	// Try to use SetContext if available (newer versions),
+	// otherwise fall back to With() for backward compatibility
+	type contextSetter interface {
+		SetContext(context.Context)
+	}
+	if setter, ok := l.(contextSetter); ok {
+		setter.SetContext(ctx)
+	} else {
+		// For older versions without SetContext, use With() instead
+		l = l.With("global", true)
+	}
 	log.SetDefault(l)
 }
 


### PR DESCRIPTION
- Use type assertion for Logger.SetContext() with fallback to With()
- Fix Gauge metrics to use Snapshot().Value() API