### PR TITLE
op-service/sources: detect duplicate blob hashes

### DIFF
--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"slices"
 	"strconv"
 	"sync"
 
@@ -355,9 +354,14 @@ func (cl *L1BeaconClient) beaconBlobs(ctx context.Context, slot uint64, hashes [
 			return nil, fmt.Errorf("compute blob kzg commitment: %w", err)
 		}
 		got := eth.KZGToVersionedHash(commitment)
-		idx := slices.IndexFunc(hashes, func(indexedHash eth.IndexedBlobHash) bool {
-			return got == indexedHash.Hash
-		})
+		idx := -1
+		for i, indexedHash := range hashes {
+			if got == indexedHash.Hash && blobs[i] == nil {
+				idx = i
+				break
+			}
+		}
+
 		if idx == -1 {
 			return nil, fmt.Errorf("received a blob hash that does not match any expected hash: %s", got)
 		}


### PR DESCRIPTION
Update blob fetching logic to handle the case where multiple blobs with the same content (but different indices in the block) are requested. When reordering the blob responses matching was done purely on blob hash which meant some output blobs were written twice and some not set at all. This resulted in an error about nil blobs. The fix is to assign to a blob hash request that hasn't previously been set.