### PR TITLE
fix: address audit findings across op-stack components

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-alpine3.21 AS builder
+FROM golang:1.24.13-alpine3.21 AS builder
 
 RUN apk add --no-cache make bash
 

--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM golang:1.24.13-alpine3.21 AS builder
+FROM golang:1.24.13-alpine3.22 AS builder
 
 RUN apk add --no-cache make bash
 

--- a/gas-oracle/Dockerfile
+++ b/gas-oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 as builder
 
 ARG VERSION=v0.0.0
 

--- a/gas-oracle/Dockerfile
+++ b/gas-oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.22 as builder
 
 ARG VERSION=v0.0.0
 
@@ -14,7 +14,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make gas-oracle VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates jq curl
 COPY --from=builder /app/gas-oracle/bin/gas-oracle /usr/local/bin/

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	golang.org/x/time v0.11.0
 	gonum.org/v1/plot v0.16.0
 	google.golang.org/api v0.215.0
-	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -312,6 +311,7 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
+	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/grpc v1.69.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.24.0
 
-toolchain go1.24.10
+toolchain go1.24.13
 
 require (
 	cloud.google.com/go/kms v1.20.1
@@ -15,7 +15,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/coder/websocket v1.8.13
-	github.com/consensys/gnark-crypto v0.18.0
+	github.com/consensys/gnark-crypto v0.18.1
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAK
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
 github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
-github.com/consensys/gnark-crypto v0.18.0 h1:vIye/FqI50VeAr0B3dx+YjeIvmc3LWz4yEfbWBpTUf0=
-github.com/consensys/gnark-crypto v0.18.0/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
+github.com/consensys/gnark-crypto v0.18.1 h1:RyLV6UhPRoYYzaFnPQA4qK3DyuDgkTgskDdoGqFt3fI=
+github.com/consensys/gnark-crypto v0.18.1/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=

--- a/kurtosis-devnet/op-program-svc/Dockerfile
+++ b/kurtosis-devnet/op-program-svc/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=op-program-base:latest
 
-FROM golang:1.24.10-alpine3.20 AS builder
+FROM golang:1.24.13-alpine3.20 AS builder
 
 COPY ./*.go /app/
 WORKDIR /app

--- a/kurtosis-devnet/op-program-svc/Dockerfile
+++ b/kurtosis-devnet/op-program-svc/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=op-program-base:latest
 
-FROM golang:1.24.13-alpine3.20 AS builder
+FROM golang:1.24.13-alpine3.22 AS builder
 
 COPY ./*.go /app/
 WORKDIR /app

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Core dependencies
-go = "1.24.10"
+go = "1.24.13"
 golangci-lint = "1.64.8"
 gotestsum = "1.12.3"
 mockery = "2.53.3"

--- a/op-acceptance-tests/mantle-tests/arsia/eip1559_params_test.go
+++ b/op-acceptance-tests/mantle-tests/arsia/eip1559_params_test.go
@@ -1,0 +1,203 @@
+package arsia
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type eip1559ParamsEnv struct {
+	l1Client     *dsl.L1ELNode
+	l2Network    *dsl.L2Network
+	l2EL         *dsl.L2ELNode
+	systemConfig eip1559ParamsSystemConfig
+}
+
+type eip1559ParamsSystemConfig struct {
+	SetEIP1559Params   func(denominator uint32, elasticity uint32) bindings.TypedCall[any] `sol:"setEIP1559Params"`
+	Eip1559Denominator func() bindings.TypedCall[uint32]                                   `sol:"eip1559Denominator"`
+	Eip1559Elasticity  func() bindings.TypedCall[uint32]                                   `sol:"eip1559Elasticity"`
+}
+
+func newEIP1559Params(t devtest.T, l2Network *dsl.L2Network, l1EL *dsl.L1ELNode, l2EL *dsl.L2ELNode) *eip1559ParamsEnv {
+	systemConfig := bindings.NewBindings[eip1559ParamsSystemConfig](
+		bindings.WithClient(l1EL.EthClient()),
+		bindings.WithTo(l2Network.Escape().Deployment().SystemConfigProxyAddr()),
+		bindings.WithTest(t))
+
+	return &eip1559ParamsEnv{
+		l1Client:     l1EL,
+		l2Network:    l2Network,
+		l2EL:         l2EL,
+		systemConfig: systemConfig,
+	}
+}
+
+func (ep *eip1559ParamsEnv) checkCompatibility(t devtest.T) {
+	_, err := contractio.Read(ep.systemConfig.Eip1559Denominator(), t.Ctx())
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func (ep *eip1559ParamsEnv) getSystemConfigOwner(t devtest.T) *dsl.EOA {
+	priv := ep.l2Network.Escape().Keys().Secret(devkeys.SystemConfigOwner.Key(ep.l2Network.ChainID().ToBig()))
+	return dsl.NewKey(t, priv).User(ep.l1Client)
+}
+
+func (ep *eip1559ParamsEnv) ownerPlan(t devtest.T) txplan.Option {
+	owner := ep.getSystemConfigOwner(t)
+	t.Log("system config owner during test", owner.Address())
+
+	elClient := ep.l1Client.Escape().EthClient()
+	return txplan.Combine(
+		owner.Plan(),
+		txplan.WithRetryInclusion(elClient, 10, retry.Exponential()),
+	)
+}
+
+func (ep *eip1559ParamsEnv) setEIP1559ParamsOnL1(t devtest.T, denominator, elasticity uint32) {
+	receipt, err := contractio.Write(ep.systemConfig.SetEIP1559Params(denominator, elasticity), t.Ctx(), ep.ownerPlan(t))
+	t.Require().NoError(err, "SetEIP1559Params transaction failed")
+
+	t.Log("tx hash", "tx hash", receipt.TxHash)
+	t.Logf("Set EIP-1559 params on L1: denominator=%d, elasticity=%d", denominator, elasticity)
+}
+
+func (ep *eip1559ParamsEnv) readL1EIP1559Params(t devtest.T) (denominator, elasticity uint32) {
+	denom, err := contractio.Read(ep.systemConfig.Eip1559Denominator(), t.Ctx())
+	t.Require().NoError(err, "reading denominator from L1")
+
+	elast, err := contractio.Read(ep.systemConfig.Eip1559Elasticity(), t.Ctx())
+	t.Require().NoError(err, "reading elasticity from L1")
+
+	return denom, elast
+}
+
+// waitForEIP1559ParamsOnL2 waits until the L2 block header extradata encodes
+// the expected denominator and elasticity.
+func (ep *eip1559ParamsEnv) waitForEIP1559ParamsOnL2(t devtest.T, expectedDenom, expectedElasticity uint32) {
+	client := ep.l2EL.Escape().L2EthClient()
+
+	t.Require().Eventually(func() bool {
+		info, err := client.InfoByLabel(t.Ctx(), "latest")
+		if err != nil {
+			return false
+		}
+
+		headerRLP, err := info.HeaderRLP()
+		if err != nil {
+			return false
+		}
+
+		var header types.Header
+		if err := rlp.DecodeBytes(headerRLP, &header); err != nil {
+			return false
+		}
+
+		// Extradata must be at least 9 bytes: version(1) + denominator(4) + elasticity(4)
+		if len(header.Extra) < 9 {
+			return false
+		}
+
+		gotDenom := binary.BigEndian.Uint32(header.Extra[1:5])
+		gotElasticity := binary.BigEndian.Uint32(header.Extra[5:9])
+		return gotDenom == expectedDenom && gotElasticity == expectedElasticity
+	}, 3*time.Minute, 5*time.Second, "L2 EIP-1559 params in block header did not sync within timeout")
+}
+
+// readL2EIP1559Params returns the denominator and elasticity currently encoded
+// in the latest L2 block header extradata.
+func (ep *eip1559ParamsEnv) readL2EIP1559Params(t devtest.T) (denominator, elasticity uint32) {
+	client := ep.l2EL.Escape().L2EthClient()
+
+	info, err := client.InfoByLabel(t.Ctx(), "latest")
+	t.Require().NoError(err)
+
+	headerRLP, err := info.HeaderRLP()
+	t.Require().NoError(err)
+
+	var header types.Header
+	t.Require().NoError(rlp.DecodeBytes(headerRLP, &header))
+	t.Require().True(len(header.Extra) >= 9, "block header extradata too short: %d bytes", len(header.Extra))
+
+	return binary.BigEndian.Uint32(header.Extra[1:5]), binary.BigEndian.Uint32(header.Extra[5:9])
+}
+
+// TestEIP1559Params sets different EIP-1559 denominator and elasticity values
+// on L1 via SystemConfig and verifies they propagate to L2 block headers.
+func TestEIP1559Params(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleMinimal(t)
+	require := t.Require()
+
+	require.True(sys.L2Chain.IsMantleForkActive(forks.MantleArsia), "Arsia fork must be active for this test")
+
+	ep := newEIP1559Params(t, sys.L2Chain, sys.L1EL, sys.L2EL)
+	ep.checkCompatibility(t)
+
+	systemOwner := ep.getSystemConfigOwner(t)
+	sys.FunderL1.FundAtLeast(systemOwner, eth.OneHundredthEther)
+
+	// Determine expected default EIP-1559 params from the rollup config.
+	// When ChainOpConfig (the Optimism field) is set, use its values;
+	// otherwise fall back to the hardcoded defaults (denominator=8, elasticity=2).
+	var expectedDefaultDenom, expectedDefaultElasticity uint32
+	rollupCfg := sys.L2Chain.Escape().RollupConfig()
+	if rollupCfg.ChainOpConfig != nil {
+		expectedDefaultDenom = uint32(rollupCfg.ChainOpConfig.EIP1559Denominator)
+		expectedDefaultElasticity = uint32(rollupCfg.ChainOpConfig.EIP1559Elasticity)
+	} else {
+		expectedDefaultDenom = 8
+		expectedDefaultElasticity = 2
+	}
+	t.Logf("Expected default EIP-1559 params from rollup config: denominator=%d, elasticity=%d",
+		expectedDefaultDenom, expectedDefaultElasticity)
+
+	// Before any changes: L1 SystemConfig should have both values at zero (initial state),
+	// while L2 block headers should carry the defaults from the rollup config.
+	origDenom, origElasticity := ep.readL1EIP1559Params(t)
+	t.Logf("Initial L1 SystemConfig EIP-1559 params: denominator=%d, elasticity=%d", origDenom, origElasticity)
+	require.Equal(uint32(0), origDenom, "initial L1 denominator should be zero")
+	require.Equal(uint32(0), origElasticity, "initial L1 elasticity should be zero")
+
+	l2Denom, l2Elast := ep.readL2EIP1559Params(t)
+	t.Logf("Initial L2 block header EIP-1559 params: denominator=%d, elasticity=%d", l2Denom, l2Elast)
+	require.Equal(expectedDefaultDenom, l2Denom, "L2 denominator should match rollup config default")
+	require.Equal(expectedDefaultElasticity, l2Elast, "L2 elasticity should match rollup config default")
+
+	testCases := []struct {
+		name        string
+		denominator uint32
+		elasticity  uint32
+	}{
+		{"LargeDenominator", 50, 6},
+		{"SmallDenominator", 2, 2},
+		{"DefaultLike", 8, 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t devtest.T) {
+			ep.setEIP1559ParamsOnL1(t, tc.denominator, tc.elasticity)
+			ep.waitForEIP1559ParamsOnL2(t, tc.denominator, tc.elasticity)
+
+			t.Log("Test completed successfully:",
+				"testCase", tc.name,
+				"denominator", tc.denominator,
+				"elasticity", tc.elasticity)
+		})
+	}
+}

--- a/op-alt-da/Dockerfile
+++ b/op-alt-da/Dockerfile
@@ -2,7 +2,7 @@ ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack
 FROM $OP_STACK_GO_BUILDER AS builder
 # See "make golang-docker" and /ops/docker/op-stack-go
 
-FROM alpine:3.20
+FROM alpine:3.22
 
 COPY --from=builder /usr/local/bin/da-server /usr/local/bin/da-server
 

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 as builder
 
 ARG VERSION=v0.0.0
 

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.22 as builder
 
 ARG VERSION=v0.0.0
 
@@ -15,7 +15,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-batcher VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -1010,7 +1010,7 @@ func (l *BatchSubmitter) sendTx(txdata txData, isCancel bool, candidate *txmgr.T
 func (l *BatchSubmitter) blobTxCandidate(data txData) (*txmgr.TxCandidate, error) {
 	var blobs []*eth.Blob
 	var err error
-	if !l.channelMgr.rollupCfg.IsMantleArsia(uint64(time.Now().Unix())) {
+	if !l.channelMgr.rollupCfg.IsMantleArsia(l.prevCurrentL1.Time) {
 		blobs, err = data.MantleBlobs()
 		if err != nil {
 			return nil, fmt.Errorf("generating mantle blobs for tx data: %w", err)

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -292,15 +292,27 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 
 	cc.InitCompressorConfig(cfg.ApproxComprRatio, cfg.Compressor, cfg.CompressionAlgo)
 
-	if cc.UseBlobs && !bs.RollupConfig.IsEcotone(uint64(time.Now().Unix())) && !bs.RollupConfig.IsMantleEverest(uint64(time.Now().Unix())) {
+	ctx, cancel := context.WithTimeout(context.Background(), bs.NetworkTimeout)
+	defer cancel()
+	l2Client, err := bs.EndpointProvider.EthClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get L2 client: %w", err)
+	}
+	l2Head, err := l2Client.BlockByNumber(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to query L2 head: %w", err)
+	}
+	headTime := l2Head.Time()
+
+	if cc.UseBlobs && !bs.RollupConfig.IsEcotone(headTime) && !bs.RollupConfig.IsMantleEverest(headTime) {
 		return errors.New("cannot use Blobs before Ecotone or MantleEverest")
 	}
-	if !cc.UseBlobs && bs.RollupConfig.IsEcotone(uint64(time.Now().Unix())) {
+	if !cc.UseBlobs && bs.RollupConfig.IsEcotone(headTime) {
 		bs.Log.Warn("Ecotone upgrade is active, but batcher is not configured to use Blobs!")
 	}
 
 	// Checking for brotli compression only post Fjord
-	if cc.CompressorConfig.CompressionAlgo.IsBrotli() && !bs.RollupConfig.IsFjord(uint64(time.Now().Unix())) {
+	if cc.CompressorConfig.CompressionAlgo.IsBrotli() && !bs.RollupConfig.IsFjord(headTime) {
 		return errors.New("cannot use brotli compression before Fjord")
 	}
 

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -217,6 +217,8 @@ func (d *L2VaultsDeployConfig) Check(log log.Logger) error {
 	if d.OperatorFeeVaultRecipient == (common.Address{}) {
 		return fmt.Errorf("%w: OperatorFeeVaultRecipient cannot be address(0)", ErrInvalidDeployConfig)
 	}
+	// At present, all fee vaults on Mantle have the same withdrawal network: L1.
+	// We temporarily comment out this check and keep it for future reference.
 	// if !d.BaseFeeVaultWithdrawalNetwork.Valid() {
 	// 	return fmt.Errorf("%w: BaseFeeVaultWithdrawalNetwork can only be 0 (L1) or 1 (L2)", ErrInvalidDeployConfig)
 	// }

--- a/op-chain-ops/genesis/mantle_config.go
+++ b/op-chain-ops/genesis/mantle_config.go
@@ -81,7 +81,7 @@ func (d *UpgradeScheduleDeployConfig) SolidityMantleForkNumber(genesisTime uint6
 			return int64(i - 4)
 		}
 	}
-	panic("should never reach here")
+	panic("SolidityMantleForkNumber: no Mantle fork (ProxyOwnerUpgrade or later) is active at genesis; check that at least one fork offset is set to 0 in the deploy config")
 }
 
 func DefaultMantleHardforkSchedule() *UpgradeScheduleDeployConfig {

--- a/op-dispute-mon/Dockerfile
+++ b/op-dispute-mon/Dockerfile
@@ -2,7 +2,7 @@ ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack
 FROM $OP_STACK_GO_BUILDER AS builder
 # See "make golang-docker" and /ops/docker/op-stack-go
 
-FROM alpine:3.20
+FROM alpine:3.22
 
 COPY --from=builder /usr/local/bin/op-dispute-mon /usr/local/bin/op-dispute-mon
 

--- a/op-e2e/actions/mantletests/derivation/blob_format_switch_test.go
+++ b/op-e2e/actions/mantletests/derivation/blob_format_switch_test.go
@@ -3,6 +3,7 @@ package derivation
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -383,4 +384,243 @@ func TestBlobFormatSwitchBeforeArsia(gt *testing.T) {
 	t.Log("Key verifications:")
 	t.Log("  1. Safe head advanced (data parsed successfully)")
 	t.Log("  2. Format switch log captured")
+}
+
+// TestBlobFormatSwitchResetCycle tests that after the DataSourceFactory switches
+// to standard blob format, a pipeline reset (via L1 reorg) resets the toggle so
+// old Mantle-format blobs are accepted again, and a subsequent new-format blob
+// triggers the switch a second time.
+//
+// Flow:
+//  1. Submit new-format blob → format switch fires, blobSourceChanged = true
+//  2. L1 reorg → pipeline reset → DataSourceFactory.Reset() → blobSourceChanged = false
+//  3. Submit old-format (Mantle) blob → accepted via MantleBlobDataSource
+//  4. Submit new-format blob → format switch fires again
+func TestBlobFormatSwitchResetCycle(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+
+	p := &e2eutils.TestParams{
+		MaxSequencerDrift:   40,
+		SequencerWindowSize: 120,
+		ChannelTimeout:      120,
+		L1BlockTime:         12,
+		AllocType:           config.DefaultAllocType,
+	}
+	dp := e2eutils.MakeMantleDeployParams(t, p)
+
+	arsiaTimeOffset := hexutil.Uint64(48)
+	upgradesHelpers.ApplyArsiaTimeOffset(dp, &arsiaTimeOffset)
+
+	sd := e2eutils.SetupMantleNormal(t, dp, helpers.DefaultAlloc)
+
+	verifLog := testlog.Logger(t, log.LevelDebug)
+	verifLogHandler := testlog.WrapCaptureLogger(verifLog.Handler())
+	verifLogger := log.NewLogger(verifLogHandler)
+
+	miner, seqEngine, sequencer := helpers.SetupSequencerTest(t, sd, testlog.Logger(t, log.LevelInfo))
+	miner.ActL1SetFeeRecipient(common.Address{'A'})
+
+	_, verifier := helpers.SetupVerifier(t, sd, verifLogger, miner.L1Client(t, sd.RollupCfg),
+		miner.BlobStore(), &sync.Config{})
+
+	rollupSeqCl := sequencer.RollupClient()
+	batcher := helpers.NewL2Batcher(testlog.Logger(t, log.LevelInfo), sd.RollupCfg, &helpers.BatcherCfg{
+		MinL1TxSize:              0,
+		MaxL1TxSize:              128_000,
+		BatcherKey:               dp.Secrets.Batcher,
+		DataAvailabilityType:     batcherFlags.BlobsType,
+		ForceSubmitSingularBatch: true,
+		EnableCellProofs:         true,
+	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
+
+	sequencer.ActL2PipelineFull(t)
+	verifier.ActL2PipelineFull(t)
+
+	genesisTime := sd.L1Cfg.Timestamp
+	arsiaActivationTime := genesisTime + uint64(arsiaTimeOffset)
+
+	// ======================================================================
+	// PHASE 1: Build baseline — submit Mantle-format batch before Arsia
+	// ======================================================================
+	t.Log("=== PHASE 1: Baseline Mantle-format batch ===")
+
+	miner.ActEmptyBlock(t)
+	miner.ActL1SafeNext(t)
+	miner.ActL1FinalizeNext(t)
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+
+	baselineL2 := seqEngine.L2Chain().CurrentBlock().Number.Uint64()
+	require.Greater(t, baselineL2, uint64(0))
+
+	batcher.ActBufferAll(t)
+	batcher.ActL2ChannelClose(t)
+	batcher.ActL2BatchSubmitMantle(t)
+	batchTX := batcher.LastSubmitted
+
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTxByHash(batchTX.Hash())(t)
+	miner.ActL1EndBlock(t)
+
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+	safeAfterBaseline := verifier.L2Safe()
+	require.Equal(t, baselineL2, safeAfterBaseline.Number)
+	t.Logf("Baseline safe head: block %d", safeAfterBaseline.Number)
+
+	// ======================================================================
+	// PHASE 2: Advance past Arsia, submit new-format blob → trigger switch
+	// ======================================================================
+	t.Log("=== PHASE 2: New-format blob → trigger format switch ===")
+
+	targetL1Time := arsiaActivationTime + 120
+	for miner.L1Chain().CurrentBlock().Time < targetL1Time {
+		miner.ActEmptyBlock(t)
+	}
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+
+	postArsiaL2 := seqEngine.L2Chain().CurrentBlock().Number.Uint64()
+	require.Greater(t, postArsiaL2, baselineL2)
+
+	batcher.ActBufferAll(t)
+	batcher.ActL2ChannelClose(t)
+	frameData1 := batcher.ReadNextOutputFrame(t)
+
+	postArsiaTime := arsiaActivationTime + 10
+	batcher.ActL2BatchSubmitMantleRawAtTime(t, frameData1, postArsiaTime)
+	newFmtTX1 := batcher.LastSubmitted
+
+	miner.ActL1SetFeeRecipient(common.Address{'A', 2})
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTxByHash(newFmtTX1.Hash())(t)
+	miner.ActL1EndBlock(t)
+	switchL1Block := miner.L1Chain().CurrentBlock()
+
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+
+	safeAfterSwitch := verifier.L2Safe()
+	require.Greater(t, safeAfterSwitch.Number, safeAfterBaseline.Number,
+		"safe head should advance after format switch")
+	t.Logf("Safe head after first format switch: block %d", safeAfterSwitch.Number)
+
+	capturingHandler, ok := verifLogHandler.(*testlog.CapturingHandler)
+	require.True(t, ok)
+
+	switchLog1 := capturingHandler.FindLog(
+		testlog.NewMessageContainsFilter("Mantle format decode failed, falling back to standard blob format"),
+	)
+	require.NotNil(t, switchLog1, "first format switch log should be present")
+	t.Log("First format switch logged")
+
+	// ======================================================================
+	// PHASE 3: L1 reorg → pipeline reset → blobSourceChanged back to false
+	// ======================================================================
+	t.Log("=== PHASE 3: L1 reorg to reset pipeline ===")
+
+	miner.ActL1RewindToParent(t)
+
+	miner.ActL1SetFeeRecipient(common.Address{'B', 1})
+	miner.ActEmptyBlock(t)
+	miner.ActL1SetFeeRecipient(common.Address{'B', 2})
+	miner.ActEmptyBlock(t)
+
+	reorgBlock := miner.L1Chain().CurrentBlock()
+	require.NotEqual(t, switchL1Block.Hash(), reorgBlock.Hash(), "L1 should have reorged")
+
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+
+	safeAfterReorg := verifier.L2Safe()
+	require.Less(t, safeAfterReorg.Number, safeAfterSwitch.Number,
+		"safe head should rewind after L1 reorg")
+	t.Logf("Safe head rewound to block %d after reorg", safeAfterReorg.Number)
+
+	// Clear logs so we can detect the second switch distinctly
+	capturingHandler.Clear()
+
+	// ======================================================================
+	// PHASE 4: Submit old-format (Mantle) blob — should be accepted again
+	// ======================================================================
+	t.Log("=== PHASE 4: Old-format (Mantle) blob after reset ===")
+
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	batcher.Reset()
+
+	sequencer.ActBuildToL1Head(t)
+
+	batcher.ActBufferAll(t)
+	batcher.ActL2ChannelClose(t)
+	batcher.ActL2BatchSubmitMantle(t)
+	oldFmtTX := batcher.LastSubmitted
+
+	miner.ActL1SetFeeRecipient(common.Address{'B', 3})
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTxByHash(oldFmtTX.Hash())(t)
+	miner.ActL1EndBlock(t)
+
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+
+	safeAfterOldFmt := verifier.L2Safe()
+	require.Greater(t, safeAfterOldFmt.Number, safeAfterReorg.Number,
+		"safe head should advance with old-format blob after reset")
+	t.Logf("Safe head after old-format blob: block %d", safeAfterOldFmt.Number)
+
+	noSwitchLog := capturingHandler.FindLog(
+		testlog.NewMessageContainsFilter("Mantle format decode failed, falling back to standard blob format"),
+	)
+	require.Nil(t, noSwitchLog,
+		"no format switch log expected — Mantle format should decode successfully")
+	t.Log("Old-format blob accepted without fallback (factory was reset)")
+
+	// ======================================================================
+	// PHASE 5: Submit new-format blob again → second format switch
+	// ======================================================================
+	t.Log("=== PHASE 5: Second new-format blob → second format switch ===")
+
+	miner.ActEmptyBlock(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+
+	batcher.ActBufferAll(t)
+	batcher.ActL2ChannelClose(t)
+	frameData2 := batcher.ReadNextOutputFrame(t)
+
+	batcher.ActL2BatchSubmitMantleRawAtTime(t, frameData2, postArsiaTime)
+	newFmtTX2 := batcher.LastSubmitted
+
+	miner.ActL1SetFeeRecipient(common.Address{'B', 4})
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTxByHash(newFmtTX2.Hash())(t)
+	miner.ActL1EndBlock(t)
+
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+
+	safeAfterSecondSwitch := verifier.L2Safe()
+	require.Greater(t, safeAfterSecondSwitch.Number, safeAfterOldFmt.Number,
+		"safe head should advance after second format switch")
+	t.Logf("Safe head after second format switch: block %d", safeAfterSecondSwitch.Number)
+
+	switchLog2 := capturingHandler.FindLog(
+		testlog.NewMessageContainsFilter("Mantle format decode failed, falling back to standard blob format"),
+	)
+	require.NotNil(t, switchLog2, "second format switch log should be present")
+	t.Log("Second format switch logged")
+
+	// ======================================================================
+	// Summary
+	// ======================================================================
+	t.Log("=== SUMMARY ===")
+	t.Logf("  Baseline safe head:                %d", safeAfterBaseline.Number)
+	t.Logf("  After 1st new-format blob:         %d (switch fired)", safeAfterSwitch.Number)
+	t.Logf("  After L1 reorg (reset):            %d (rewound)", safeAfterReorg.Number)
+	t.Logf("  After old-format blob (re-accepted): %d (no switch)", safeAfterOldFmt.Number)
+	t.Logf("  After 2nd new-format blob:         %d (switch fired again)", safeAfterSecondSwitch.Number)
+	t.Log("Test PASSED: DataSourceFactory reset cycle verified")
 }

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -33,7 +33,7 @@ RUN <<-EOF
     tar -xzf "${DOWNLOAD_PATH}" -C /usr/local/bin forge
 EOF
 
-FROM --platform=$BUILDPLATFORM golang:1.24.10-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-bookworm AS builder
 
 ARG VERSION=v0.0.0
 

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -168,11 +168,16 @@ var Subcommands = cli.Commands{
 			// MANTLE_FEATURES
 			// SystemConfig contract has not yet upgraded to have startBlock() method,
 			// so we need to fetch the L1 start block from the L1 starting block tag.
+			if config.L1StartingBlockTag == nil {
+				return fmt.Errorf("L1StartingBlockTag is required but not set in deploy config")
+			}
 			var l1StartBlock *types.Block
 			if config.L1StartingBlockTag.BlockHash != nil {
 				l1StartBlock, err = client.BlockByHash(context.Background(), *config.L1StartingBlockTag.BlockHash)
 			} else if config.L1StartingBlockTag.BlockNumber != nil {
 				l1StartBlock, err = client.BlockByNumber(context.Background(), big.NewInt(config.L1StartingBlockTag.BlockNumber.Int64()))
+			} else {
+				return fmt.Errorf("L1StartingBlockTag must specify either a block hash or block number")
 			}
 			if err != nil {
 				return fmt.Errorf("error getting l1 start block: %w", err)

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -378,7 +378,7 @@ var (
 		EnvVars: prefixEnvVars("L2_BACKUP_UNSAFE_SYNC_RPC"),
 		Hidden:  true,
 	}
-	BackupL2UnsafeSyncRPCTrustRPC = &cli.StringFlag{
+	BackupL2UnsafeSyncRPCTrustRPC = &cli.BoolFlag{
 		Name: "l2.backup-unsafe-sync-rpc.trustrpc",
 		Usage: "Like l1.trustrpc, configure if response data from the RPC needs to be verified, e.g. blockhash computation." +
 			"This does not include checks if the blockhash is part of the canonical chain.",

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -493,9 +493,16 @@ func initL1BeaconAPI(ctx context.Context, cfg *config.Config, node *OpNode) (*so
 	if cfg.Rollup.EcotoneTime == nil && cfg.Rollup.MantleEverestTime == nil {
 		return nil, nil
 	}
-	// Once the Ecotone upgrade is scheduled, we must have initialized the Beacon API settings.
+	// Once the Ecotone/MantleEverest upgrade is scheduled, we must have initialized the Beacon API settings.
 	if cfg.Beacon == nil {
-		return nil, fmt.Errorf("missing L1 Beacon Endpoint configuration: this API is mandatory for Ecotone upgrade at t=%d", *cfg.Rollup.EcotoneTime)
+		var forkDesc string
+		switch {
+		case cfg.Rollup.EcotoneTime != nil:
+			forkDesc = fmt.Sprintf("Ecotone upgrade at t=%d", *cfg.Rollup.EcotoneTime)
+		case cfg.Rollup.MantleEverestTime != nil:
+			forkDesc = fmt.Sprintf("MantleEverest upgrade at t=%d", *cfg.Rollup.MantleEverestTime)
+		}
+		return nil, fmt.Errorf("missing L1 Beacon Endpoint configuration: this API is mandatory for %s", forkDesc)
 	}
 
 	// We always initialize a client. We will get an error on requests if the client does not work.

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -96,6 +96,12 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	return src, nil
 }
 
+// Reset clears the blob source toggle so that the next OpenData can choose the appropriate source from scratch.
+func (ds *DataSourceFactory) Reset() error {
+	ds.blobSourceChanged = false
+	return nil
+}
+
 // DataSourceConfig regroups the mandatory rollup.Config fields needed for DataFromEVMTransactions.
 type DataSourceConfig struct {
 	l1Signer          types.Signer

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -13,6 +13,7 @@ import (
 
 type DataAvailabilitySource interface {
 	OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address) (DataIter, error)
+	Reset() error
 }
 
 type NextBlockProvider interface {
@@ -77,6 +78,9 @@ func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
 // internal invariants that later propagate up the derivation pipeline.
 func (l1r *L1Retrieval) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.SystemConfig) error {
 	var err error
+	if err = l1r.dataSrc.Reset(); err != nil {
+		return fmt.Errorf("failed to reset data source: %w", err)
+	}
 	if l1r.datas, err = l1r.dataSrc.OpenData(ctx, base, sysCfg.BatcherAddr); err != nil {
 		return fmt.Errorf("failed to open data source: %w", err)
 	}

--- a/op-node/rollup/derive/l1_retrieval_test.go
+++ b/op-node/rollup/derive/l1_retrieval_test.go
@@ -40,8 +40,20 @@ func (m *MockDataSource) OpenData(ctx context.Context, ref eth.L1BlockRef, batch
 	return out[0].(DataIter), nil
 }
 
+func (m *MockDataSource) Reset() error {
+	out := m.Mock.MethodCalled("Reset")
+	if out[0] == nil {
+		return nil
+	}
+	return out[0].(error)
+}
+
 func (m *MockDataSource) ExpectOpenData(ref eth.L1BlockRef, iter DataIter, batcherAddr common.Address) {
 	m.Mock.On("OpenData", ref, batcherAddr).Return(iter)
+}
+
+func (m *MockDataSource) ExpectReset() {
+	m.Mock.On("Reset").Return(nil)
 }
 
 var _ DataAvailabilitySource = (*MockDataSource)(nil)
@@ -89,12 +101,13 @@ func TestL1RetrievalReset(t *testing.T) {
 		BatcherAddr: common.Address{42},
 	}
 
+	dataSrc.ExpectReset()
 	dataSrc.ExpectOpenData(a, &fakeDataIter{}, l1Cfg.BatcherAddr)
 	defer dataSrc.AssertExpectations(t)
 
 	l1r := NewL1Retrieval(testlog.Logger(t, log.LevelError), dataSrc, nil)
 
-	// We assert that it opens up the correct data on a reset
+	// We assert that it resets the data source then opens up the correct data on a reset
 	_ = l1r.Reset(context.Background(), a, l1Cfg)
 }
 

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.10-alpine3.21
+ARG GO_VERSION=1.24.13-alpine3.21
 ARG EXPORT_TARGET=current
 FROM golang:${GO_VERSION} AS src
 

--- a/op-program/Dockerfile.repro
+++ b/op-program/Dockerfile.repro
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.13-alpine3.21
+ARG GO_VERSION=1.24.13-alpine3.22
 ARG EXPORT_TARGET=current
 FROM golang:${GO_VERSION} AS src
 

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.13-alpine3.21
+ARG GO_VERSION=1.24.13-alpine3.22
 ARG VM_TARGET=current
 FROM golang:${GO_VERSION} AS builder
 

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.10-alpine3.21
+ARG GO_VERSION=1.24.13-alpine3.21
 ARG VM_TARGET=current
 FROM golang:${GO_VERSION} AS builder
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 as builder
 
 ARG VERSION=v0.0.0
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.22 as builder
 
 ARG VERSION=v0.0.0
 
@@ -15,7 +15,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-proposer VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin
 

--- a/op-service/crypto/signature.go
+++ b/op-service/crypto/signature.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"strings"
 
@@ -55,14 +56,17 @@ type SignerFactory func(chainID *big.Int) SignerFn
 // SignerFactoryFromConfig considers three ways that signers are created & then creates single factory from those config options.
 // It can either take a remote signer (via opsigner.CLIConfig) or it can be provided either a mnemonic + derivation path or a private key.
 // It prefers the remote signer, then the mnemonic or private key (only one of which can be provided).
-func SignerFactoryFromConfig(l log.Logger, privateKey, mnemonic, hdPath string, signerConfig opsigner.CLIConfig, enableHsm bool, hsmCreden, hsmAddress, hsmAPIName string) (SignerFactory, common.Address, error) {
+// The returned io.Closer must be called during shutdown to release resources (e.g. KMS gRPC connections).
+func SignerFactoryFromConfig(l log.Logger, privateKey, mnemonic, hdPath string, signerConfig opsigner.CLIConfig, enableHsm bool, hsmCreden, hsmAddress, hsmAPIName string) (SignerFactory, common.Address, io.Closer, error) {
 	var signer SignerFactory
 	var fromAddress common.Address
+	var closer io.Closer
+	closer = io.NopCloser(nil)
 	if signerConfig.Enabled() {
 		signerClient, err := opsigner.NewSignerClientFromConfig(l, signerConfig)
 		if err != nil {
 			l.Error("Unable to create Signer Client", "error", err)
-			return nil, common.Address{}, fmt.Errorf("failed to create the signer client: %w", err)
+			return nil, common.Address{}, nil, fmt.Errorf("failed to create the signer client: %w", err)
 		}
 		fromAddress = common.HexToAddress(signerConfig.Address)
 		signer = func(chainID *big.Int) SignerFn {
@@ -76,12 +80,12 @@ func SignerFactoryFromConfig(l log.Logger, privateKey, mnemonic, hdPath string, 
 	} else if enableHsm {
 		proBytes, err := hex.DecodeString(hsmCreden)
 		if err != nil {
-			return nil, common.Address{}, err
+			return nil, common.Address{}, nil, err
 		}
 		apikey := option.WithCredentialsJSON(proBytes)
 		client, err := kms.NewKeyManagementClient(context.Background(), apikey)
 		if err != nil {
-			return nil, common.Address{}, err
+			return nil, common.Address{}, nil, err
 		}
 		mk := &hsm.ManagedKey{
 			KeyName:      hsmAPIName,
@@ -99,18 +103,19 @@ func SignerFactoryFromConfig(l log.Logger, privateKey, mnemonic, hdPath string, 
 		}
 
 		log.Info("tx-mgr", "enable-hsm", true)
+		closer = client
 	} else {
 		var privKey *ecdsa.PrivateKey
 		var err error
 
 		if privateKey != "" && mnemonic != "" {
-			return nil, common.Address{}, errors.New("cannot specify both a private key and a mnemonic")
+			return nil, common.Address{}, nil, errors.New("cannot specify both a private key and a mnemonic")
 		}
 		if privateKey == "" {
 			// Parse l2output wallet private key and L2OO contract address.
 			wallet, err := hdwallet.NewFromMnemonic(mnemonic)
 			if err != nil {
-				return nil, common.Address{}, fmt.Errorf("failed to parse mnemonic: %w", err)
+				return nil, common.Address{}, nil, fmt.Errorf("failed to parse mnemonic: %w", err)
 			}
 
 			privKey, err = wallet.PrivateKey(accounts.Account{
@@ -119,12 +124,12 @@ func SignerFactoryFromConfig(l log.Logger, privateKey, mnemonic, hdPath string, 
 				},
 			})
 			if err != nil {
-				return nil, common.Address{}, fmt.Errorf("failed to create a wallet: %w", err)
+				return nil, common.Address{}, nil, fmt.Errorf("failed to create a wallet: %w", err)
 			}
 		} else {
 			privKey, err = crypto.HexToECDSA(strings.TrimPrefix(privateKey, "0x"))
 			if err != nil {
-				return nil, common.Address{}, fmt.Errorf("failed to parse the private key: %w", err)
+				return nil, common.Address{}, nil, fmt.Errorf("failed to parse the private key: %w", err)
 			}
 		}
 		// we force the curve to Geth's instance, because Geth does an equality check in the nocgo version:
@@ -139,5 +144,5 @@ func SignerFactoryFromConfig(l log.Logger, privateKey, mnemonic, hdPath string, 
 		}
 	}
 
-	return signer, fromAddress, nil
+	return signer, fromAddress, closer, nil
 }

--- a/op-service/crypto/signature_test.go
+++ b/op-service/crypto/signature_test.go
@@ -31,8 +31,9 @@ func TestSignerFactoryFromKey(t *testing.T) {
 func testSigner(t *testing.T, priv, mnemonic, hdPath string, cfg signer.CLIConfig) {
 	logger := testlog.Logger(t, log.LevelDebug)
 
-	factoryFn, addr, err := SignerFactoryFromConfig(logger, priv, mnemonic, hdPath, cfg, false, "", "", "")
+	factoryFn, addr, signerCloser, err := SignerFactoryFromConfig(logger, priv, mnemonic, hdPath, cfg, false, "", "", "")
 	require.NoError(t, err)
+	defer signerCloser.Close()
 	expectedAddr := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 	require.Equal(t, expectedAddr, addr)
 	chainID := big.NewInt(10)

--- a/op-service/hsm/hsm_signer.go
+++ b/op-service/hsm/hsm_signer.go
@@ -9,8 +9,8 @@ import (
 	"math/big"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
 	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
-	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 
 	// lots of poor naming in go-ethereum 👾
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"

--- a/op-service/hsm/hsm_signer.go
+++ b/op-service/hsm/hsm_signer.go
@@ -19,6 +19,11 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+var (
+	secp256k1N     = new(big.Int).Set(crypto.S256().Params().N)
+	secp256k1HalfN = new(big.Int).Rsh(secp256k1N, 1)
+)
+
 // ManagedKey represents a key from the Key Management Service (KMS).
 type ManagedKey struct {
 	// KMS uses a slash-separated path for identification.
@@ -100,6 +105,10 @@ func (mk *ManagedKey) SignHash(ctx context.Context, hash common.Hash) ([]byte, e
 		rLen = (params.R.BitLen() + 7) / 8
 	}
 	if params.S != nil {
+		// Enforce low-s canonicalization (EIP-2) to prevent signature malleability.
+		if params.S.Cmp(secp256k1HalfN) > 0 {
+			params.S.Sub(secp256k1N, params.S)
+		}
 		sLen = (params.S.BitLen() + 7) / 8
 	}
 	if rLen == 0 || rLen > 32 || sLen == 0 || sLen > 32 {

--- a/op-service/sources/backup_sync_client.go
+++ b/op-service/sources/backup_sync_client.go
@@ -59,6 +59,9 @@ func SyncClientDefaultConfig(config *rollup.Config, trustRPC bool) *SyncClientCo
 }
 
 func NewSyncClient(receiver receivePayload, client client.RPC, log log.Logger, metrics caching.Metrics, config *SyncClientConfig) (*SyncClient, error) {
+	if receiver == nil {
+		return nil, ErrNoUnsafeL2PayloadChannel
+	}
 	l2Client, err := NewL2Client(client, log, metrics, &config.L2ClientConfig)
 	if err != nil {
 		return nil, err

--- a/op-service/sources/backup_sync_client.go
+++ b/op-service/sources/backup_sync_client.go
@@ -101,14 +101,14 @@ func (s *SyncClient) RequestL2Range(ctx context.Context, start, end eth.L2BlockR
 
 	endNum := end.Number
 	if end == (eth.L2BlockRef{}) {
-		n, err := s.rollupCfg.TargetBlockNumber(uint64(time.Now().Unix()))
+		unsafeHead, err := s.L2BlockRefByLabel(ctx, eth.Unsafe)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to query backup RPC for latest unsafe head: %w", err)
 		}
-		if n <= start.Number {
+		if unsafeHead.Number <= start.Number {
 			return nil
 		}
-		endNum = n
+		endNum = unsafeHead.Number
 	}
 
 	// TODO(CLI-3635): optimize the by-range fetching with the Engine API payloads-by-range method.

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"sync/atomic"
@@ -450,7 +451,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 		hdPath = cfg.L2OutputHDPath
 	}
 
-	signerFactory, from, err := opcrypto.SignerFactoryFromConfig(l, cfg.PrivateKey, cfg.Mnemonic, hdPath, cfg.SignerCLIConfig, cfg.EnableHsm, cfg.HsmCreden, cfg.HsmAddress, cfg.HsmAPIName)
+	signerFactory, from, signerCloser, err := opcrypto.SignerFactoryFromConfig(l, cfg.PrivateKey, cfg.Mnemonic, hdPath, cfg.SignerCLIConfig, cfg.EnableHsm, cfg.HsmCreden, cfg.HsmAddress, cfg.HsmAPIName)
 	if err != nil {
 		return nil, fmt.Errorf("could not init signer: %w", err)
 	}
@@ -490,10 +491,11 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	cellProofTime := fallbackToOsakaCellProofTimeIfKnown(chainID, cfg.CellProofTime)
 
 	res := Config{
-		Backend: l1,
-		ChainID: chainID,
-		Signer:  signerFactory(chainID),
-		From:    from,
+		Backend:      l1,
+		ChainID:      chainID,
+		Signer:       signerFactory(chainID),
+		From:         from,
+		SignerCloser: signerCloser,
 
 		TxSendTimeout:              cfg.TxSendTimeout,
 		TxNotInMempoolTimeout:      cfg.TxNotInMempoolTimeout,
@@ -608,6 +610,10 @@ type Config struct {
 	// Signer is used to sign transactions when the gas price is increased.
 	Signer opcrypto.SignerFn
 	From   common.Address
+
+	// SignerCloser holds the lifecycle handle for the signer backend (e.g. KMS gRPC client).
+	// It is closed when the tx manager shuts down.
+	SignerCloser io.Closer
 
 	// GasPriceEstimatorFn is used to estimate the gas price for a transaction.
 	// If nil, DefaultGasPriceEstimatorFn is used.

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -424,7 +424,7 @@ func ReadCLIConfig(ctx cliiface.Context) CLIConfig {
 	}
 }
 
-func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
+func NewConfig(cfg CLIConfig, l log.Logger) (_ *Config, err error) {
 	if err := cfg.Check(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
@@ -455,6 +455,11 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not init signer: %w", err)
 	}
+	defer func() {
+		if err != nil {
+			signerCloser.Close()
+		}
+	}()
 
 	feeLimitThreshold, err := eth.GweiToWei(cfg.FeeLimitThresholdGwei)
 	if err != nil {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -205,6 +205,9 @@ func (m *SimpleTxManager) API() rpc.API {
 // once closed, the tx manager will refuse to send any new transactions, and may abandon pending ones.
 func (m *SimpleTxManager) Close() {
 	m.backend.Close()
+	if m.cfg.SignerCloser != nil {
+		m.cfg.SignerCloser.Close()
+	}
 	m.closed.Store(true)
 }
 

--- a/ops/docker/deployment-utils/Dockerfile
+++ b/ops/docker/deployment-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-bookworm AS go-base
+FROM golang:1.24.13-bookworm AS go-base
 
 RUN go install github.com/tomwright/dasel/v2/cmd/dasel@master
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -53,7 +53,7 @@ EOF
 RUN forge --version
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go bash just
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -17,7 +17,7 @@ ARG UBUNTU_TARGET_BASE_IMAGE=ubuntu:22.04
 ARG KONA_VERSION=none
 
 # builder_foundry does not need to be built on $BUILDPLATFORM, as foundry produces static binaries.
-FROM alpine:3.21 AS builder_foundry
+FROM alpine:3.22 AS builder_foundry
 
 # Build args are only-available in top-level by default, so we'll need to declare it inside the stage too
 ARG TARGETARCH
@@ -53,7 +53,7 @@ EOF
 RUN forge --version
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.22 AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go bash just
 

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -51,6 +51,13 @@ contract SystemConfig is OwnableUpgradeable, Semver {
     bytes32 public constant UNSAFE_BLOCK_SIGNER_SLOT = keccak256("systemconfig.unsafeblocksigner");
 
     /**
+     * @notice The maximum gas limit that can be set for L2 blocks. This limit is used to enforce
+     *         that the blocks on L2 are not too large to process and prove. Over time, this value
+     *         can be increased as various optimizations and improvements are made to the system.
+     */
+    uint64 internal constant MAX_GAS_LIMIT = 500_000_000;
+
+    /**
      * @notice Fixed L2 gas overhead. Used as part of the L2 fee calculation.
      */
     uint256 public overhead;
@@ -202,6 +209,7 @@ contract SystemConfig is OwnableUpgradeable, Semver {
         _setUnsafeBlockSigner(_unsafeBlockSigner);
         _setResourceConfig(_config);
         require(_gasLimit >= minimumGasLimit(), "SystemConfig: gas limit too low");
+        require(_gasLimit <= maximumGasLimit(), "SystemConfig: gas limit too high");
     }
 
     /**
@@ -215,6 +223,17 @@ contract SystemConfig is OwnableUpgradeable, Semver {
      */
     function minimumGasLimit() public view returns (uint64) {
         return uint64(_resourceConfig.maxResourceLimit) + uint64(_resourceConfig.systemTxMaxGas);
+    }
+
+    /**
+     * @notice Returns the maximum L2 gas limit that can be safely set for the system to
+     *         operate. This bound is used to prevent the gas limit from being set too high
+     *         and causing the system to be unable to process and/or prove L2 blocks.
+     *
+     * @return uint64 Maximum gas limit.
+     */
+    function maximumGasLimit() public pure returns (uint64) {
+        return MAX_GAS_LIMIT;
     }
 
     /**
@@ -279,6 +298,7 @@ contract SystemConfig is OwnableUpgradeable, Semver {
      */
     function setGasLimit(uint64 _gasLimit) external onlyOwner {
         require(_gasLimit >= minimumGasLimit(), "SystemConfig: gas limit too low");
+        require(_gasLimit <= maximumGasLimit(), "SystemConfig: gas limit too high");
         gasLimit = _gasLimit;
 
         bytes memory data = abi.encode(_gasLimit);

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 // Interfaces
-// import { ISemver } from "interfaces/universal/ISemver.sol";
 import { Semver } from "src/universal/Semver.sol";
 import { L1Block } from "src/L2/L1Block.sol";
 

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -6,9 +6,6 @@ import { Constants } from "src/libraries/Constants.sol";
 
 import { Semver } from "../universal/Semver.sol";
 
-// // Interfaces
-// import { ISemver } from "interfaces/universal/ISemver.sol";
-
 /**
  * @custom:proxied
  * @custom:predeploy 0x4200000000000000000000000000000000000015

--- a/packages/contracts-bedrock/src/L2/OperatorFeeVault.sol
+++ b/packages/contracts-bedrock/src/L2/OperatorFeeVault.sol
@@ -14,5 +14,5 @@ contract OperatorFeeVault is FeeVault, Semver {
      *
      * @param _recipient Address that will receive the accumulated fees.
      */
-    constructor(address _recipient) FeeVault(_recipient, 10 ether) Semver(1, 1, 0) { }
+    constructor(address _recipient) FeeVault(_recipient, 10 ether) Semver(1, 0, 0) { }
 }


### PR DESCRIPTION
## Summary
- Fix wall clock usage in batcher setup and op-node initialization, replacing with monotonic clock where appropriate
- Fix potential nil dereference and unclosed KMS signer client during init failure
- Add explicit low-s canonicalization in KMS signature conversion
- Enforce explicit maximum bound for gas limit in SystemConfig
- Fix backup L2 unsafe trust-rpc flag type mismatch
- Fix deprecated types in HSM signer
- Reset `blobSourceChanged` flag during derivation pipeline reset
- Fix natspec semver mismatch in OperatorFeeVault
- Remove commented-out code
- Bump Go to 1.24.13 and gnark-crypto to address known vulnerabilities

## Tests
- Add EIP-1559 param acceptance test
- Add e2e test for data source factory reset with blob format switch