### PR TITLE
fix(op-node): add NotFound tolerance to CheckL2GenesisBlockHash

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -570,7 +570,7 @@ func initL2(ctx context.Context, cfg *config.Config, node *OpNode) (*sources.Eng
 		return nil, nil, nil, nil, fmt.Errorf("failed to create Engine client: %w", err)
 	}
 
-	if err := cfg.Rollup.ValidateL2Config(ctx, l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
+	if err := cfg.Rollup.ValidateL2Config(ctx, node.log, l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
 		return nil, nil, nil, nil, err
 	}
 

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -212,7 +212,7 @@ func (cfg *Config) ValidateL1Config(ctx context.Context, logger log.Logger, clie
 }
 
 // ValidateL2Config checks L2 config variables for errors.
-func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client, skipL2GenesisBlockHash bool) error {
+func (cfg *Config) ValidateL2Config(ctx context.Context, logger log.Logger, client L2Client, skipL2GenesisBlockHash bool) error {
 	// Validate the L2 Client Chain ID
 	if err := cfg.CheckL2ChainID(ctx, client); err != nil {
 		return err
@@ -222,7 +222,7 @@ func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client, skipL2
 	if skipL2GenesisBlockHash {
 		return nil
 	}
-	if err := cfg.CheckL2GenesisBlockHash(ctx, client); err != nil {
+	if err := cfg.CheckL2GenesisBlockHash(ctx, logger, client); err != nil {
 		return err
 	}
 
@@ -299,9 +299,15 @@ func (cfg *Config) CheckL2ChainID(ctx context.Context, client L2Client) error {
 }
 
 // CheckL2GenesisBlockHash checks that the configured L2 genesis block hash is valid for the given client.
-func (cfg *Config) CheckL2GenesisBlockHash(ctx context.Context, client L2Client) error {
+func (cfg *Config) CheckL2GenesisBlockHash(ctx context.Context, logger log.Logger, client L2Client) error {
 	l2GenesisBlockRef, err := client.L2BlockRefByNumber(ctx, cfg.Genesis.L2.Number)
 	if err != nil {
+		if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) {
+			// Genesis block isn't available to check (e.g. snapshot-imported EL without genesis block),
+			// so just accept it and hope for the best — same as CheckL1GenesisBlockHash behavior.
+			logger.Warn("L2 genesis block not found, skipping validity check")
+			return nil
+		}
 		return fmt.Errorf("failed to get L2 genesis blockhash: %w", err)
 	}
 	if l2GenesisBlockRef.Hash != cfg.Genesis.L2.Hash {

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -399,6 +400,7 @@ func TestActivations(t *testing.T) {
 type mockL2Client struct {
 	chainID *big.Int
 	Hash    common.Hash
+	err     error
 }
 
 func (m *mockL2Client) ChainID(context.Context) (*big.Int, error) {
@@ -406,6 +408,9 @@ func (m *mockL2Client) ChainID(context.Context) (*big.Int, error) {
 }
 
 func (m *mockL2Client) L2BlockRefByNumber(ctx context.Context, number uint64) (eth.L2BlockRef, error) {
+	if m.err != nil {
+		return eth.L2BlockRef{}, m.err
+	}
 	return eth.L2BlockRef{
 		Hash:   m.Hash,
 		Number: 100,
@@ -418,7 +423,8 @@ func TestValidateL2Config(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
+	logger := testlog.Logger(t, log.LvlInfo)
+	err := config.ValidateL2Config(context.TODO(), logger, &mockClient, false)
 	assert.NoError(t, err)
 }
 
@@ -428,10 +434,11 @@ func TestValidateL2ConfigInvalidChainIdFails(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
+	logger := testlog.Logger(t, log.LvlInfo)
+	err := config.ValidateL2Config(context.TODO(), logger, &mockClient, false)
 	assert.Error(t, err)
 	config.L2ChainID = big.NewInt(99)
-	err = config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err = config.ValidateL2Config(context.TODO(), logger, &mockClient, false)
 	assert.Error(t, err)
 }
 
@@ -441,10 +448,11 @@ func TestValidateL2ConfigInvalidGenesisHashFails(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x00}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
+	logger := testlog.Logger(t, log.LvlInfo)
+	err := config.ValidateL2Config(context.TODO(), logger, &mockClient, false)
 	assert.Error(t, err)
 	config.Genesis.L2.Hash = [32]byte{0x02}
-	err = config.ValidateL2Config(context.TODO(), &mockClient, false)
+	err = config.ValidateL2Config(context.TODO(), logger, &mockClient, false)
 	assert.Error(t, err)
 }
 
@@ -454,10 +462,11 @@ func TestValidateL2ConfigInvalidGenesisHashSkippedWhenRequested(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x00}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient, true)
+	logger := testlog.Logger(t, log.LvlInfo)
+	err := config.ValidateL2Config(context.TODO(), logger, &mockClient, true)
 	assert.NoError(t, err)
 	config.Genesis.L2.Hash = [32]byte{0x02}
-	err = config.ValidateL2Config(context.TODO(), &mockClient, true)
+	err = config.ValidateL2Config(context.TODO(), logger, &mockClient, true)
 	assert.NoError(t, err)
 }
 
@@ -473,18 +482,66 @@ func TestCheckL2ChainID(t *testing.T) {
 }
 
 func TestCheckL2BlockRefByNumber(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
 	config := randConfig()
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.CheckL2GenesisBlockHash(context.TODO(), &mockClient)
+	err := config.CheckL2GenesisBlockHash(context.TODO(), logger, &mockClient)
 	assert.NoError(t, err)
 	mockClient.Hash = common.Hash{0x02}
-	err = config.CheckL2GenesisBlockHash(context.TODO(), &mockClient)
+	err = config.CheckL2GenesisBlockHash(context.TODO(), logger, &mockClient)
 	assert.Error(t, err)
 	mockClient.Hash = common.Hash{0x00}
-	err = config.CheckL2GenesisBlockHash(context.TODO(), &mockClient)
+	err = config.CheckL2GenesisBlockHash(context.TODO(), logger, &mockClient)
 	assert.Error(t, err)
+
+	// Test NotFound tolerance: when L2 genesis block is not available
+	// (e.g. snapshot-imported EL), the check should be skipped gracefully.
+	mockClient.err = errors.New("block not found")
+	err = config.CheckL2GenesisBlockHash(context.Background(), logger, &mockClient)
+	assert.NoError(t, err)
+}
+
+func TestCheckL2GenesisBlockHashNotFound(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	config := randConfig()
+	config.Genesis.L2.Number = 100
+	config.Genesis.L2.Hash = [32]byte{0x01}
+
+	tests := []struct {
+		name      string
+		err       error
+		expectErr bool
+	}{
+		{
+			name:      "not found error is tolerated",
+			err:       fmt.Errorf("failed to determine L2BlockRef of height 100, could not get payload: %w", ethereum.NotFound),
+			expectErr: false,
+		},
+		{
+			name:      "block not found string is tolerated",
+			err:       errors.New("block not found"),
+			expectErr: false,
+		},
+		{
+			name:      "other errors are not tolerated",
+			err:       errors.New("connection refused"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockL2Client{chainID: big.NewInt(100), err: tt.err}
+			err := config.CheckL2GenesisBlockHash(context.Background(), logger, mockClient)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestConfig_Check(t *testing.T) {


### PR DESCRIPTION
When L2 EL is started from a snapshot import (e.g. block 36000000), the original genesis block (e.g. block 325709) is not in the database. This caused op-node to crash at startup, forcing operators to modify rollup.json with a custom genesis config. That custom config in turn caused span batch timestamp decoding to be offset by 826 days (71,350,385 seconds), dropping all span batches as "future" and permanently stalling safe block advancement after the Arsia upgrade activated Delta (span batch support).

Fix: add the same NotFound graceful handling to CheckL2GenesisBlockHash that CheckL1GenesisBlockHash already has — when the genesis block is not found, log a warning and skip the validity check instead of crashing. This allows using the original rollup.json with correct Genesis.L2Time, fixing span batch decoding.

Safety: Chain ID check still runs unconditionally, and FindL2Heads provides runtime genesis hash validation. This is strictly more conservative than the existing EL sync mode which skips the check unconditionally.

Also adds comprehensive tests for NotFound tolerance covering:
- ethereum.NotFound wrapped errors
- "block not found" string matching
- Non-NotFound errors still fail correctly