### PR TITLE
docs: add Mantle Arsia CertiK audit report to security reviews

### DIFF
--- a/docs/security-reviews/README.md
+++ b/docs/security-reviews/README.md
@@ -91,6 +91,14 @@ These are upstream OP Stack audit reports inherited from the Optimism codebase. 
 
 ---
 
+## Mantle Arsia Audit Report
+
+| Audit Time | Reviewer | Report Link                                                                           | Audited Commit |
+|------------|----------|---------------------------------------------------------------------------------------|----------------|
+| 2026-03    | CertiK   | [CertiK - Mantle Network Audit Report](./mantle-arsia/CertiK-REP-Mantle-Network.pdf) |                |
+
+---
+
 ## Notes
 
 - All audit reports are conducted by reputable third-party auditors to ensure the security and robustness of the Mantle network.


### PR DESCRIPTION
## Summary
- Adds the Mantle Arsia audit section to `docs/security-reviews/README.md`
- Includes the CertiK audit report (2026-03) linking to `mantle-arsia/CertiK-REP-Mantle-Network.pdf`

## Test plan
- [x] Verify the markdown table renders correctly on GitHub
- [x] Verify the PDF link resolves to the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)