### PR TITLE
fix: correct grammar in code comments and tests

### DIFF
--- a/op-acceptance-tests/mantle-tests/arsia/min_base_fee_test.go
+++ b/op-acceptance-tests/mantle-tests/arsia/min_base_fee_test.go
@@ -133,7 +133,7 @@ func (mbf *minBaseFeeEnv) waitForMinBaseFeeConfigChangeOnL2(t devtest.T, expecte
 	t.Logf("actual chain EIP-1559 params from block header: denominator: %d, elasticity: %d", denominator, elasticity)
 
 	expectedExtraData := eth.BytesMax32(eip1559.EncodeMinBaseFeeExtraData(uint64(denominator), uint64(elasticity), expected))
-	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesnt match")
+	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesn't match")
 }
 
 // TestMinBaseFee verifies configurable minimum base fee using devstack presets.

--- a/op-acceptance-tests/tests/jovian/min_base_fee.go
+++ b/op-acceptance-tests/tests/jovian/min_base_fee.go
@@ -113,7 +113,7 @@ func (mbf *minBaseFeeEnv) waitForMinBaseFeeConfigChangeOnL2(t devtest.T, expecte
 		return got == expected
 	}, 2*time.Minute, 5*time.Second, "L2 min base fee in block header did not sync within timeout")
 
-	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesnt match")
+	t.Require().Equal(expectedExtraData, eth.BytesMax32(actualBlockExtraData), "block header extradata doesn't match")
 }
 
 // TestMinBaseFee verifies configurable minimum base fee using devstack presets.

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -842,7 +842,7 @@ func (oc *OpConductor) stopSequencer() error {
 
 	// Quoting (@zhwrd): StopSequencer is called after conductor loses leadership. In the event that
 	// the StopSequencer call fails, it actually has little real consequences because the sequencer
-	// cant produce a block and gossip / commit it to the raft log (requires leadership). Once
+	// can't produce a block and gossip / commit it to the raft log (requires leadership). Once
 	// conductor comes back up it will check its leader and sequencer state and attempt to stop the
 	// sequencer again. So it is "okay" to fail to stop a sequencer, the state will eventually be
 	// rectified and we won't have two active sequencers that are actually producing blocks.

--- a/op-service/endpoint/rpc.go
+++ b/op-service/endpoint/rpc.go
@@ -120,7 +120,7 @@ func (url WsURL) WsRPC() string {
 }
 
 // WsOrHttpRPC provides optionality between
-// a websocket RPC endpoint and a HTTP RPC endpoint.
+// a websocket RPC endpoint and an HTTP RPC endpoint.
 // The default is the websocket endpoint.
 type WsOrHttpRPC struct {
 	WsURL   string

--- a/op-service/eth/blobs_api_test.go
+++ b/op-service/eth/blobs_api_test.go
@@ -17,7 +17,7 @@ type dataJson struct {
 }
 
 // TestAPIGenesisResponse tests that json unmarshalling a json response from a
-// eth/v1/beacon/genesis beacon node call into a APIGenesisResponse object
+// eth/v1/beacon/genesis beacon node call into an APIGenesisResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
 // This also confirms that the [sources.L1BeaconClient] correctly parses
@@ -42,7 +42,7 @@ func TestAPIGenesisResponse(t *testing.T) {
 }
 
 // TestAPIConfigResponse tests that json unmarshalling a json response from a
-// eth/v1/config/spec beacon node call into a APIConfigResponse object
+// eth/v1/config/spec beacon node call into an APIConfigResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
 // This also confirms that the [sources.L1BeaconClient] correctly parses
@@ -67,7 +67,7 @@ func TestAPIConfigResponse(t *testing.T) {
 }
 
 // TestAPIGetBlobSidecarsResponse tests that json unmarshalling a json response from a
-// eth/v1/beacon/blob_sidecars/<X> beacon node call into a APIGetBlobSidecarsResponse object
+// eth/v1/beacon/blob_sidecars/<X> beacon node call into an APIGetBlobSidecarsResponse object
 // fills all existing fields with the expected values, thereby confirming that
 // APIGenesisResponse is compatible with the current beacon node API.
 // This also confirms that the [sources.L1BeaconClient] correctly parses

--- a/op-service/rpc/handler.go
+++ b/op-service/rpc/handler.go
@@ -30,7 +30,7 @@ var wildcardHosts = []string{"*"}
 //
 // Custom routes can also be added with AddHandler, these are registered to the underlying http.ServeMux.
 //
-// If more customization is needed, this Handler can be composed in a HTTP stack of your own.
+// If more customization is needed, this Handler can be composed in an HTTP stack of your own.
 // Use http.StripPrefix to clean the URL route prefix that this Handler is registered on (leave no prefix).
 type Handler struct {
 	appVersion     string

--- a/op-service/signer/cli.go
+++ b/op-service/signer/cli.go
@@ -35,7 +35,7 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 		},
 		&cli.StringSliceFlag{
 			Name:    HeadersFlagName,
-			Usage:   "Headers to pass to the remote signer. Format `key=value`. Value can contain any character allowed in a HTTP header. When using env vars, split with commas. When using flags one key value pair per flag.",
+			Usage:   "Headers to pass to the remote signer. Format `key=value`. Value can contain any character allowed in an HTTP header. When using env vars, split with commas. When using flags one key value pair per flag.",
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "HEADER"),
 		},
 	}


### PR DESCRIPTION
## Description
Fixed grammatical errors in code comments and test files.

⚠️ **Note:** Comment and test changes only. No functional code modified. This is a minor documentation improvement.

## Changes
- Fixed `a API` → `an API` (3 occurrences)
- Fixed `a HTTP` → `an HTTP` (3 occurrences)
- Fixed `doesnt` → `doesn't` in test assertions
- Fixed `cant` → `can't` in comments

## Files Modified
- op-service/eth/blobs_api_test.go
- op-service/endpoint/rpc.go
- op-service/rpc/handler.go
- op-service/signer/cli.go
- op-acceptance-tests/tests/jovian/min_base_fee.go
- op-acceptance-tests/mantle-tests/arsia/min_base_fee_test.go
- op-conductor/conductor/service.go

## Impact
- Documentation and test readability improvement
- No functional changes to Mantle L2 logic