### PR TITLE
chore: retire mantle-xyz/evm fork, drop dead token_ratio trait method

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -291,7 +291,8 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.34.0"
-source = "git+https://github.com/mantle-xyz/evm?branch=mantle-v0.34.0#b91d0077aae4181c74f98405453304c477ddaa43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -3565,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4160,8 +4161,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4782,7 +4783,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5192,7 +5193,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12962,7 +12963,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13042,7 +13043,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13979,10 +13980,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15233,7 +15234,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -683,6 +683,3 @@ revm-precompile = { git = "https://github.com/mantle-xyz/revm", branch = "mantle
 revm-primitives = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
 revm-state = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
 op-revm = { git = "https://github.com/mantle-xyz/revm", branch = "mantle-elysium" }
-
-# alloy-evm: redirected to mantle-xyz/evm @ mantle-v0.34.0 (v0.34.0 + Mantle token_ratio trait method)
-alloy-evm = { git = "https://github.com/mantle-xyz/evm", branch = "mantle-v0.34.0" }

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -20,7 +20,7 @@ pub mod error;
 pub use error::{OpTxError, map_op_err};
 
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, IntoTxEnv, precompiles::PrecompilesMap};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes};
 use core::{
     fmt::Debug,
     marker::PhantomData,
@@ -310,10 +310,6 @@ where
             self.inner.0.inspector.inner_mut(),
             &mut self.inner.0.precompiles,
         )
-    }
-
-    fn token_ratio(&self) -> U256 {
-        U256::ZERO
     }
 }
 

--- a/rust/alloy-op-evm/src/post_exec/mod.rs
+++ b/rust/alloy-op-evm/src/post_exec/mod.rs
@@ -138,10 +138,6 @@ where
     fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
         self.inner.components_mut()
     }
-
-    fn token_ratio(&self) -> alloy_primitives::U256 {
-        self.inner.token_ratio()
-    }
 }
 
 impl<F, DB, I> PostExecEvm for PostExecEvmAdapter<F::Evm<DB, I>, F, DB, I>

--- a/rust/op-reth/crates/rpc/src/eth/receipt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/receipt.rs
@@ -294,6 +294,10 @@ impl OpReceiptFieldsBuilder {
                 operator_fee_scalar,
                 operator_fee_constant,
                 da_footprint_gas_scalar,
+                // [MANTLE] Jovian-class RPC field. This subtree is not the production op-reth
+                // (CI builds the binary from src/reth) and does not implement per-tx token_ratio
+                // surfacing; initialize to null, matching the default constructor in production.
+                token_ratio: None,
             },
             op_gas_refund,
             deposit_nonce,

--- a/rust/op-reth/examples/custom-node/src/evm/alloy.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/alloy.rs
@@ -1,7 +1,7 @@
 use crate::evm::{CustomTxEnv, PaymentTxEnv};
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use alloy_op_evm::{OpEvm, OpEvmContext, OpEvmFactory, OpTx, OpTxError};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes};
 use op_revm::{L1BlockInfo, OpHaltReason, OpSpecId, OpTransaction, precompiles::OpPrecompiles};
 use revm::{
     Context, Inspector, Journal,
@@ -110,10 +110,6 @@ where
 
     fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
         self.inner.components_mut()
-    }
-
-    fn token_ratio(&self) -> U256 {
-        self.inner.token_ratio()
     }
 }
 


### PR DESCRIPTION
## Summary

Retires the `mantle-xyz/evm` fork and switches `alloy-evm` back to upstream crates.io **v0.34.0**.

The fork existed for exactly one reason: a Mantle-added `Evm::token_ratio()` required method on alloy-evm's `Evm` trait. That method is **dead code** — no consumer reads it, and every implementation returns `U256::ZERO` (or forwards to a ZERO impl). The real token ratio flows through op-revm's `L1BlockInfo.token_ratio`, populated from the `GAS_ORACLE` storage slot, and is **not** affected by this change.

Removing the trait method makes the fork byte-for-byte identical to upstream `alloy-evm v0.34.0`, so we drop the `[patch.crates-io]` redirect and depend on the published crate.

## Changes

- **`rust/Cargo.toml`** — remove the `alloy-evm = { git = "mantle-xyz/evm", branch = "mantle-v0.34.0" }` patch; keep `alloy-evm = "0.34.0"` from crates.io.
- **`rust/Cargo.lock`** — `alloy-evm` now resolves to `registry+crates.io` (checksum `c1ceeea6…`). Incidental transitive bumps (windows-sys/link/result/core, getrandom) from the stale lock are included.
- **`rust/alloy-op-evm/src/lib.rs`** — remove the `OpEvm` `token_ratio` impl + now-unused `U256` import.
- **`rust/alloy-op-evm/src/post_exec/mod.rs`** — remove the `PostExecEvmAdapter` `token_ratio` forwarder.
- **`rust/op-reth/examples/custom-node/src/evm/alloy.rs`** — remove the `CustomEvm` `token_ratio` forwarder + now-unused `U256` import.

## Pre-existing build break (also fixed)

While verifying the workspace builds, found an **unrelated, pre-existing** break: commit `888c13728` added the Jovian-class `token_ratio: Option<u128>` field to the op-alloy RPC `L1BlockInfo` struct but never updated the `rust/op-reth` receipt builder constructor, causing `E0063 missing field 'token_ratio'` in `reth-optimism-rpc` / `op-reth` / `example-custom-node`. Confirmed it reproduces on a pristine `mantle-elysium` checkout.

This subtree is **not** the production op-reth (CI downloads the binary built from `src/reth`) and does not implement per-tx token_ratio RPC surfacing. Fixed minimally by initializing `token_ratio: None` in the builder — matching the default constructor in production `src/reth`. Full RPC surfacing of token_ratio in this subtree is out of scope.

## Test plan

- [x] `cargo check -p alloy-op-evm` passes against upstream alloy-evm v0.34.0
- [x] `cargo check -p reth-optimism-rpc` passes (pre-existing break resolved)
- [x] `cargo check -p op-reth -p example-custom-node` passes
- [x] Zero remaining references to `mantle-xyz/evm` in the workspace
- [x] CI green