### PR TITLE
ci: update op-reth to op-reth-v2.2.1-mantle-elysium.1-rc1

### DIFF
--- a/.github/workflows/ci-main-migrated.yml
+++ b/.github/workflows/ci-main-migrated.yml
@@ -582,7 +582,7 @@ jobs:
 
       - name: Install op-reth
         env:
-          OP_RETH_VERSION: "v2.2.1"
+          OP_RETH_VERSION: "op-reth-v2.2.1-mantle-elysium.1-rc1"
         run: |
           set -euo pipefail
           TARBALL="op-reth-${OP_RETH_VERSION}-x86_64-unknown-linux-gnu.tar.gz"


### PR DESCRIPTION
## Summary
- Update `OP_RETH_VERSION` in CI from `v2.2.1` to `op-reth-v2.2.1-mantle-elysium.1-rc1`
- Points to the latest mantle-elysium release of op-reth which includes:
  - `engine_getPayloadV5` support (required for Limb fork)
  - Osaka chainspec mapping at Limb timestamp
  - Version string with branch name
  - Release CI (cross x86_64 + aarch64)

## Test plan
- [x] op-reth acceptance tests passed locally: 48/48 PASS (sysgo, mantle-base gate)
- [x] Release tarball available at `mantle-xyz/reth` releases
- [x] CI runs acceptance tests with new binary