### PR TITLE
fix(contracts): disable forge lint-on-build

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -1,3 +1,8 @@
+# Disable forge lint-on-build: foundry 1.5.1's linter aborts the build on
+# pre-existing warnings in these contracts. Linting is not needed to compile.
+[lint]
+lint_on_build = false
+
 ################################################################
 #                   PROFILE: DEFAULT (local)                   #
 ################################################################


### PR DESCRIPTION
## What
Disable `forge` lint-on-build for `contracts-bedrock`.

## Why
foundry 1.5.1's `forge build` runs the linter and **aborts the build** on
pre-existing lint warnings in these contracts, which fails `just build-contracts`
(build-no-tests) and therefore the rde-v3 `task build`. Linting is a quality
check, not required to compile artifacts.

## Change
`packages/contracts-bedrock/foundry.toml`:
```toml
[lint]
lint_on_build = false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
