### PR TITLE
test(preconf): add reorg ordering/dedup acceptance tests

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -142,3 +142,9 @@ gates:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/mantle-tests/base/deposit
         name: TestDepositMNTByBridge_WithoutMsgValue
         timeout: 5m
+
+  - id: mantle-preconf
+    description: "Mantle preconf acceptance tests. Require DEVSTACK_L2EL_KIND=op-reth (tests skip under op-geth, which has preconf disabled)."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/mantle-tests/preconf/...
+        timeout: 15m

--- a/op-acceptance-tests/mantle-tests/preconf/reorg/helpers_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg/helpers_test.go
@@ -1,0 +1,28 @@
+package reorg
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// waitL2HeadSettled polls until the L2 unsafe head stops advancing (two equal
+// reads ~1s apart). A just-stopped op-node sequencer can still have an in-flight
+// block committing; building on the head before it settles would build on a
+// stale parent and lose to op-node's last block.
+func waitL2HeadSettled(t devtest.T, el *dsl.L2ELNode) eth.L2BlockRef {
+	var last eth.L2BlockRef
+	first := true
+	t.Require().Eventuallyf(func() bool {
+		cur := el.BlockRefByLabel(eth.Unsafe)
+		if first || cur.Number != last.Number {
+			last, first = cur, false
+			return false
+		}
+		last = cur
+		return true
+	}, 30*time.Second, 1*time.Second, "L2 unsafe head must settle after StopSequencer")
+	return last
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg/init_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg/init_test.go
@@ -1,0 +1,20 @@
+package reorg
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		// Test-sequencer topology (so we can drive a real reorg) with the
+		// Mantle preconf subsystem enabled on the L2 EL. Only op-reth honours
+		// preconf, so these tests require DEVSTACK_L2EL_KIND=op-reth and skip
+		// otherwise.
+		presets.WithNewMantleSingleChainMultiNodeWithTestSeqPreconf(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithNoDiscovery(),
+	)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg/reorg_dedup_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg/reorg_dedup_test.go
@@ -1,0 +1,134 @@
+package reorg
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestPreconfCommitmentNotDuplicatedByReplayAfterReorg is the op-acceptance-tests
+// realization of TC-RG5.
+//
+// The test plan marks TC-RG5 as "QA does not execute" because a *single*
+// sequencer cannot isolate the internal conflict it targets: when a reorg
+// reverts the commitment block, the reverted tx's nonce is un-consumed on the
+// new fork, so preconf replay simply re-lands it — you never get "the new chain
+// already contains the tx AND replay hits an already-consumed nonce" in one
+// build. That pure internal-skip path is pinned by the reth integration test
+// `reorg_replay_nonce_consumed.rs`.
+//
+// What IS observable end-to-end here is the *contract* RG5 protects — "链上该
+// hash 有且仅有一笔、节点不崩溃": after a real reorg re-lands the commitment, a
+// lingering journal/replay entry for it must NOT resurrect or duplicate the tx
+// in any subsequent block, and the sender must keep working. Concretely, once
+// the tx re-lands and the chain advances, the sender's nonce is consumed, so
+// `sync_fifo_forward_to_head` must forward past (and drop) the stale entry on
+// every later build — the same consumed-nonce cleanup RG5 is about, exercised
+// through the black-box chain state.
+//
+// This goes beyond TC-RG2, which stops at the single re-land: here we keep
+// building, assert the commitment stays in exactly one canonical block, and
+// assert the same sender's next nonce still lands.
+func TestPreconfCommitmentNotDuplicatedByReplayAfterReorg(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Freeze the safe head so the block carrying the commitment stays unsafe —
+	// only unsafe blocks are reverted by the L1-origin rewrite below.
+	sys.L2Batcher.Stop()
+	gt.Cleanup(func() { sys.L2Batcher.Start() })
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Advance L1 until the L2 unsafe head sits on an L1 origin past our start.
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	// Submit a preconf commitment and locate the unsafe block that carried it.
+	// Reuse the same funded sender for the continuity check below — PlanTransfer
+	// derives the nonce from pending state, so a later send picks up nonce+1.
+	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	txHash := sendPreconf(t, ctx, sys.L2EL, alice, bob.Address(), eth.OneHundredthEther)
+
+	rec := waitReceipt(t, sys.L2EL, txHash)
+	l2WithTx := sys.L2EL.BlockRefByNumber(rec.BlockNumber.Uint64())
+	require.NotZero(l2WithTx.L1Origin.Number,
+		"commitment block must have a non-genesis L1 origin to reorg")
+	logger.Info("commitment landed", "l2", l2WithTx, "l1Origin", l2WithTx.L1Origin)
+
+	// Reorg out the commitment block's L1 origin, exactly as TC-RG2 does.
+	l1Before := sys.L1EL.BlockRefByNumber(l2WithTx.L1Origin.Number)
+	logger.Info("triggering L1 reorg", "l1", l1Before)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	sys.L1EL.WaitForBlockNumber(l1Before.Number)
+	require.NotEqual(sys.L1EL.BlockRefByNumber(l1Before.Number).Hash, l1Before.Hash,
+		"L1 must have reorged")
+
+	sys.L2EL.ReorgTriggered(l2WithTx, 30)
+	require.NotEqual(l2WithTx.Hash, sys.L2EL.BlockRefByNumber(l2WithTx.Number).Hash,
+		"the original commitment block must no longer be canonical after the reorg")
+
+	// The commitment re-lands, same hash, in exactly one canonical block.
+	reRec := assertReLandedCanonical(t, sys.L2EL, txHash)
+	reLandBlock := reRec.BlockNumber.Uint64()
+	logger.Info("commitment re-landed after reorg", "hash", txHash, "block", reLandBlock)
+
+	// ── RG5 core: keep building past the re-land. The sender's nonce is now
+	// consumed on the canonical chain, so any lingering replay/journal entry for
+	// this commitment must be forwarded past and skipped on every later build —
+	// never re-applied. Advancing the chain is what makes that cleanup
+	// observable as black-box chain state.
+	const extraBlocks = 4
+	require.Eventuallyf(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		return sys.L2EL.BlockRefByLabel(eth.Unsafe).Number >= reLandBlock+extraBlocks
+	}, 90*time.Second, 2*time.Second,
+		"unsafe head must advance >=%d blocks past the re-land (block %d)", extraBlocks, reLandBlock)
+
+	// The commitment must still be canonical in exactly ONE block, and the SAME
+	// one it re-landed in — a stale replay entry must not resurrect it into a
+	// later block or duplicate it. assertReLandedCanonical rejects orphaned/
+	// duplicate inclusion; the block-number equality rejects silent relocation.
+	reRec2 := assertReLandedCanonical(t, sys.L2EL, txHash)
+	require.Equalf(reLandBlock, reRec2.BlockNumber.Uint64(),
+		"commitment must stay in its single re-landed block %d, not move/duplicate (now %d)",
+		reLandBlock, reRec2.BlockNumber.Uint64())
+
+	// Sender continuity: a fresh commitment from the same sender (next nonce)
+	// must still land canonically — proving the lingering entry did not wedge
+	// nonce accounting and the node is healthy after the repeated cleanup.
+	txHash2 := sendPreconf(t, ctx, sys.L2EL, alice, bob.Address(), eth.OneHundredthEther)
+	require.NotEqual(txHash, txHash2, "second commitment must be a distinct tx (next nonce)")
+	reRec3 := assertReLandedCanonical(t, sys.L2EL, txHash2)
+	logger.Info("same-sender next-nonce commitment landed after reorg cleanup",
+		"hash", txHash2, "block", reRec3.BlockNumber)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg/reorg_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg/reorg_test.go
@@ -1,0 +1,504 @@
+// Package reorg verifies the Mantle preconf must-land guarantee across a
+// chain reorg.
+//
+// A preconf tx that returns `success` is a must-land commitment: the client
+// was promised the tx will end up on chain. If a reorg reverts the (unsafe)
+// block that carried it, the commitment must still hold — the tx has to
+// re-land on the new canonical chain (same hash, exactly once). Internally
+// this relies on the reverted tx being re-injected into the pool and
+// re-applied as a replayed commitment, but these tests only assert the
+// black-box outcome.
+//
+// A real reorg is driven the same way as the sync/elsync reorg tests: with an
+// in-process test sequencer we rewrite an L1 block on an ancestor parent, and
+// op-node cascades the L1 reorg into an L2 unsafe reorg that reverts the block
+// carrying the commitment. This requires the in-process sysgo orchestrator and
+// op-reth as the L2 EL (preconf is only wired for op-reth).
+//
+// Coverage maps to the "Reorg 专项 (TC-RG)" cases of the preconf test plan:
+//
+//   - TestPreconfCommitmentSurvivesReorg           — TC-RG2 (1-block shallow reorg)
+//   - TestPreconfCommitmentsSurviveMultiBlockReorg  — TC-RG3 (2~3 block shallow reorg,
+//     multi-commitment list; no commitment dropped)
+//   - TestPreconfCommitmentSurvivesDroppedPayload   — TC-RG1 (carryover; skipped, see
+//     its doc comment for the harness limitation)
+//
+// The `reorg_drift` warn log that TC-RG2 also mentions is emitted by the
+// op-reth subprocess (Rust tracing); asserting it from the Go harness is
+// brittle, so it is left to reth's own integration tests — here we assert only
+// the black-box chain state (re-land + no duplicate inclusion).
+package reorg
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// preconfEvent decodes the subset of `eth_sendRawTransactionWithPreconf`'s
+// result we assert on. Field names match mantle-reth's PreconfTxEvent serde
+// (crates/rpc-ext/src/lib.rs); the omitted `receipt` field is ignored.
+// The wire is camelCase: mantle-reth's PreconfTxEvent derives
+// `#[serde(rename_all = "camelCase")]` (crates/rpc-ext/src/lib.rs), so the
+// JSON keys are `txHash` / `blockHeight`, not snake_case. Tagging these
+// `tx_hash` / `block_height` silently decodes them to zero.
+type preconfEvent struct {
+	TxHash      common.Hash    `json:"txHash"`
+	Status      string         `json:"status"` // "success" | "failed" | "timeout" | "waiting"
+	Reason      string         `json:"reason"`
+	BlockHeight hexutil.Uint64 `json:"blockHeight"`
+}
+
+// TestPreconfCommitmentSurvivesReorg commits a preconf tx into an unsafe
+// block, reorgs that block out, and asserts the tx re-lands on the new chain.
+func TestPreconfCommitmentSurvivesReorg(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Freeze the safe head so the block carrying the commitment stays unsafe —
+	// only unsafe blocks are reverted by the L1-origin rewrite below.
+	sys.L2Batcher.Stop()
+	gt.Cleanup(func() { sys.L2Batcher.Start() })
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+
+	// Fund the sender FIRST — while L1/L2 still advance freely (before we freeze L1
+	// below), so the funding tx reliably gets mined; and on an early L1 origin that
+	// the later reorg will NOT revert. Otherwise the sender is unfunded at the new
+	// tip and reth (correctly) rejects the re-injected tx for insufficient funds, so
+	// it never re-lands.
+	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	fundOrigin := sys.L2EL.BlockRefByLabel(eth.Unsafe).L1Origin.Number
+
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Advance L1 one block at a time until the L2 unsafe head sits on an L1
+	// origin past our starting point — that origin is what we later reorg.
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	// Submit a preconf tx. It must be accepted (the must-land commitment) and
+	// land in the current unsafe block.
+	txHash := sendPreconf(t, ctx, sys.L2EL, alice, bob.Address(), eth.OneHundredthEther)
+
+	// Locate the unsafe block that carried the committed tx.
+	rec := waitReceipt(t, sys.L2EL, txHash)
+	l2WithTx := sys.L2EL.BlockRefByNumber(rec.BlockNumber.Uint64())
+	require.NotZero(l2WithTx.L1Origin.Number,
+		"commitment block must have a non-genesis L1 origin to reorg")
+	logger.Info("commitment landed", "l2", l2WithTx, "l1Origin", l2WithTx.L1Origin)
+
+	// The reorg origin must be strictly above the funding origin, else the sender
+	// loses its funding in the reorg (see the funding comment above).
+	require.Greaterf(l2WithTx.L1Origin.Number, fundOrigin,
+		"commitment origin %d must exceed funding origin %d", l2WithTx.L1Origin.Number, fundOrigin)
+
+	// Reorg out the L1 origin of the commitment block: rebuild that L1 height on
+	// its parent, then resume so the alternate L1 chain wins. op-node detects the
+	// L1 reorg and cascades it into an L2 unsafe reorg that reverts the commitment.
+	//
+	// Freeze the L2 head first so it does NOT keep sequencing (~2s/block) for the
+	// ~20s the L1 rebuild takes — that would pile blocks onto the commitment origin
+	// and produce a DEEP reorg. Resume only once the L1 reorg has propagated past
+	// the old head, so op-node applies the reset promptly.
+	oldL1Head := sys.L1EL.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2CL.StopSequencer()
+
+	l1Before := sys.L1EL.BlockRefByNumber(l2WithTx.L1Origin.Number)
+	logger.Info("triggering L1 reorg", "l1", l1Before)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	require.Eventuallyf(func() bool {
+		h := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		return h.Number > oldL1Head &&
+			sys.L1EL.BlockRefByNumber(l1Before.Number).Hash != l1Before.Hash
+	}, 120*time.Second, 2*time.Second, "L1 reorg must propagate past old head %d", oldL1Head)
+	require.NotEqual(sys.L1EL.BlockRefByNumber(l1Before.Number).Hash, l1Before.Hash, "L1 must have reorged")
+	sys.L2CL.StartSequencer()
+
+	// Depth-tolerant revert wait: the L1-origin reorg may span >1 unsafe block, so
+	// the strict parent-preserving ReorgTriggered check is not applicable here.
+	waitReverted(t, sys.L2EL, l2WithTx, 30)
+	// The block that originally carried the commitment must be gone from the
+	// canonical chain — otherwise there was no real reorg and the re-land
+	// assertion below would be vacuous.
+	require.NotEqual(l2WithTx.Hash, sys.L2EL.BlockRefByNumber(l2WithTx.Number).Hash,
+		"the original commitment block must no longer be canonical after the reorg")
+	logger.Info("L2 reorg triggered; commitment block reverted", "reverted", l2WithTx)
+
+	// SLA: the committed tx must re-land on the new canonical chain, same hash,
+	// exactly once. Poll for its receipt to reappear, then confirm the block it
+	// now sits in is canonical (a tx hash can only be canonical in one block).
+	reRec := assertReLandedCanonical(t, sys.L2EL, txHash)
+	logger.Info("commitment re-landed after reorg", "hash", txHash, "block", reRec.BlockNumber)
+}
+
+// TestPreconfCommitmentsSurviveMultiBlockReorg (TC-RG3) commits several preconf
+// txs spread across a few consecutive unsafe blocks, reorgs all of those blocks
+// out at once, and asserts every commitment re-lands on the new chain — none
+// dropped, none duplicated. This exercises the deeper (2~3 block) reorg path
+// that the single-block TC-RG2 test does not.
+func TestPreconfCommitmentsSurviveMultiBlockReorg(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Freeze the safe head so the blocks carrying the commitments stay unsafe —
+	// only unsafe blocks are reverted by the L1-origin rewrite below.
+	sys.L2Batcher.Stop()
+	gt.Cleanup(func() { sys.L2Batcher.Start() })
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+
+	// Fund all senders FIRST — while L1/L2 still advance freely (before we freeze L1
+	// below), so all 4 funding txs reliably get mined; and on an early L1 origin the
+	// later reorg will NOT revert (else they are unfunded at the new tip and reth
+	// rejects the re-injected txs for insufficient funds). A fresh EOA per
+	// commitment keeps nonces independent.
+	const numCommitments = 4
+	// Fund sequentially (NOT NewFundedEOAs, which funds concurrently and races the
+	// single faucet account's nonce — flaky for count>1).
+	alices := make([]*dsl.EOA, numCommitments)
+	for i := range alices {
+		alices[i] = sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	}
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	fundOrigin := sys.L2EL.BlockRefByLabel(eth.Unsafe).L1Origin.Number
+
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Advance L1 until the L2 unsafe head sits on an L1 origin past our start.
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	// Submit several preconf commitments, advancing L1 (and hence the L2 unsafe
+	// head) between each so they land in distinct, consecutive unsafe blocks.
+	type commitment struct {
+		hash  common.Hash
+		block eth.L2BlockRef
+	}
+	commitments := make([]commitment, 0, numCommitments)
+	for i := range numCommitments {
+		h := sendPreconf(t, ctx, sys.L2EL, alices[i], bob.Address(), eth.OneHundredthEther)
+		rec := waitReceipt(t, sys.L2EL, h)
+		blk := sys.L2EL.BlockRefByNumber(rec.BlockNumber.Uint64())
+		require.NotZero(blk.L1Origin.Number, "commitment block must have a non-genesis L1 origin")
+		commitments = append(commitments, commitment{hash: h, block: blk})
+		logger.Info("commitment landed", "i", i, "hash", h, "l2", blk.Number, "l1Origin", blk.L1Origin.Number)
+
+		// Advance L1 by one and wait for the L2 unsafe head to move past this
+		// block, so the next commitment lands strictly later.
+		if i < numCommitments-1 {
+			require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+			require.NoError(ts.Next(ctx))
+			require.Eventuallyf(func() bool {
+				return sys.L2EL.BlockRefByLabel(eth.Unsafe).Number > blk.Number
+			}, 60*time.Second, 2*time.Second, "awaiting unsafe head to advance past block %d", blk.Number)
+		}
+	}
+
+	// Identify the shallowest (earliest) and deepest commitment blocks.
+	earliest, deepest := commitments[0].block, commitments[0].block
+	for _, c := range commitments {
+		if c.block.Number < earliest.Number {
+			earliest = c.block
+		}
+		if c.block.Number > deepest.Number {
+			deepest = c.block
+		}
+	}
+	require.Greater(deepest.Number, earliest.Number,
+		"commitments must span >=2 unsafe blocks to exercise a multi-block reorg")
+
+	// Reorg out the earliest commitment block's L1 origin. Because every later
+	// commitment block was built on an L1 origin >= that height, reverting it
+	// reverts the earliest block and all its descendants — the whole commitment
+	// set in one shot.
+	require.Greaterf(earliest.L1Origin.Number, fundOrigin,
+		"earliest commitment origin %d must exceed funding origin %d", earliest.L1Origin.Number, fundOrigin)
+
+	// Freeze the L2 head so the revert stays bounded to the commitment blocks (see
+	// TC-RG2); resume once the L1 reorg has propagated past the old head so op-node
+	// applies the reset promptly.
+	oldL1Head := sys.L1EL.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2CL.StopSequencer()
+
+	l1Before := sys.L1EL.BlockRefByNumber(earliest.L1Origin.Number)
+	logger.Info("triggering multi-block L1 reorg", "l1", l1Before,
+		"revertFromL2", earliest.Number, "throughL2", deepest.Number)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	require.Eventuallyf(func() bool {
+		h := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		return h.Number > oldL1Head &&
+			sys.L1EL.BlockRefByNumber(l1Before.Number).Hash != l1Before.Hash
+	}, 120*time.Second, 2*time.Second, "L1 reorg must propagate past old head %d", oldL1Head)
+	require.NotEqual(sys.L1EL.BlockRefByNumber(l1Before.Number).Hash, l1Before.Hash, "L1 must have reorged")
+	sys.L2CL.StartSequencer()
+
+	// Wait for the earliest (shallowest) commitment block to be reverted. Its
+	// descendants — every other commitment block — are then necessarily reverted
+	// too (a block cannot stay canonical if its ancestor is gone).
+	waitReverted(t, sys.L2EL, earliest, 30)
+	logger.Info("L2 multi-block reorg triggered", "reverted from", earliest.Number)
+
+	// SLA: every commitment must re-land on the new canonical chain, same hash,
+	// exactly once — none dropped, none duplicated.
+	for _, c := range commitments {
+		reRec := assertReLandedCanonical(t, sys.L2EL, c.hash)
+		logger.Info("commitment re-landed after multi-block reorg",
+			"hash", c.hash, "origBlock", c.block.Number, "newBlock", reRec.BlockNumber)
+	}
+}
+
+// TestPreconfCommitmentSurvivesDroppedPayload (TC-RG1) asserts the carryover
+// guarantee: a preconf commitment whose payload is built but then discarded
+// *without a reorg* (the payload is never committed) must still re-land on the
+// next build via FIFO carryover — the same hash, exactly once.
+//
+// Unlike TC-RG2/RG3, this is NOT a reorg: no committed block is reverted. The
+// mechanism under test (reth's in-memory `replay_fifo_carryover` Success-branch,
+// `reset_success_to_waiting`) fires only when a Success FIFO entry survives an
+// *uncommitted* payload — a state op-node's normal auto-sequencing never leaves
+// behind (it commits every block it builds). So we take L2 sequencing away from
+// op-node and drive it through the test sequencer's L2 control API, entirely
+// over the CL path (op-node opstack API -> engine API):
+//
+//  1. Open a build on parent H, commit a preconf tx into it (Success = must-land).
+//  2. Cancel the build — abandon it without sealing (no getPayload) or committing.
+//     Head stays at H; the tx is not on chain; the Success FIFO entry survives
+//     (its nonce is un-consumed on H).
+//  3. Open a *fresh* build on the SAME parent H. For reth to run a new
+//     build_payload (and thus the carryover pass) rather than return the cached
+//     build#1 job, the attributes must differ, so build#2 uses the next L1 origin
+//     O2 (distinct L1-info tx -> distinct payloadId). Carryover re-dispatches the
+//     surviving Success entry into build#2.
+//
+// The `landed.L1Origin == O2` assertion is what makes this non-vacuous: it proves
+// the tx re-landed in a genuinely new build (build#2), not a cached build#1.
+func TestPreconfCommitmentSurvivesDroppedPayload(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Fund the preconf sender BEFORE we stop op-node's sequencer — funding needs
+	// a block to be mined, which only op-node produces while it is sequencing.
+	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+
+	// Let op-node advance the L2 chain onto a non-genesis L1 origin before we take
+	// over — build#2 needs a *next* origin O2, which only exists once the head's
+	// origin is past genesis and the L1 head runs ahead of it.
+	require.Eventuallyf(func() bool {
+		h := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return h.L1Origin.Number > 0 && sys.L1EL.BlockRefByLabel(eth.Unsafe).Number > h.L1Origin.Number
+	}, 90*time.Second, 1*time.Second, "L2 head must reach a non-genesis L1 origin with L1 ahead")
+
+	// Take L2 sequencing away from op-node so we can build-then-drop deterministically.
+	sys.L2CL.StopSequencer()
+	gt.Cleanup(func() { sys.L2CL.StartSequencer() })
+
+	tsL2 := sys.TestSequencer.Escape().ControlAPI(sys.L2Chain.ChainID())
+	require.NotNil(tsL2, "L2 control API must be wired")
+
+	// A just-stopped op-node may still have an in-flight block committing; wait for
+	// the head to settle before we treat it as the parent.
+	head0 := waitL2HeadSettled(t, sys.L2EL)
+	o1 := sys.L1EL.BlockRefByNumber(head0.L1Origin.Number)
+	require.NotZero(o1.Number, "parent must have a non-genesis L1 origin")
+	require.Greater(sys.L1EL.BlockRefByLabel(eth.Unsafe).Number, o1.Number,
+		"L1 head must run ahead of the L2 origin so the next origin O2 exists")
+	o2 := sys.L1EL.BlockRefByNumber(o1.Number + 1)
+	o1Hash, o2Hash := o1.Hash, o2.Hash
+
+	// Advance L2 (pinned to origin O1, so the origin does not auto-advance) until
+	// the head's time reaches O2's time — only then is O2 a valid origin for the
+	// next block (L2 time must be >= its L1 origin time).
+	require.Eventuallyf(func() bool {
+		head := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		if head.Time >= o2.Time {
+			return true
+		}
+		require.NoError(tsL2.New(ctx, seqtypes.BuildOpts{Parent: head.Hash, L1Origin: &o1Hash}))
+		require.NoError(tsL2.Next(ctx))
+		return false
+	}, 60*time.Second, 500*time.Millisecond, "L2 head time must reach O2 time %d", o2.Time)
+
+	parent := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	require.GreaterOrEqual(parent.Time, o2.Time)
+	logger.Info("drop-scenario parent", "l2", parent.Number, "time", parent.Time,
+		"o1", o1.Number, "o2", o2.Number, "o2Time", o2.Time)
+
+	// ── build#1 (dropped): open on parent H with origin O1, commit a preconf tx
+	// into it (Success = must-land commitment), then ABANDON it without sealing.
+	// `ensure_only_one_payload` guarantees this Open cancels any leftover op-node
+	// build on the same parent, so the preconf lands in THIS build (not a lingering
+	// orphan that never seals).
+	require.NoError(tsL2.New(ctx, seqtypes.BuildOpts{Parent: parent.Hash, L1Origin: &o1Hash}), "New build#1")
+	require.NoError(tsL2.Open(ctx), "Open build#1")
+
+	// Let the build subscribe to the fifo broadcast before we push. A preconf
+	// pushed before the build subscribes falls into the "dead window" and this
+	// build misses it (reth's builder interval is ~100ms; op-node normally holds
+	// the build a full slot before getPayload).
+	time.Sleep(600 * time.Millisecond)
+
+	txHash := sendPreconf(t, ctx, sys.L2EL, alice, bob.Address(), eth.OneHundredthEther)
+	logger.Info("preconf committed into build#1 (Success)", "hash", txHash)
+
+	require.NoError(tsL2.Cancel(ctx), "Cancel build#1 (drop payload: no getPayload, no commit)")
+
+	// The dropped payload never committed: the head must still be H, and the
+	// committed tx must NOT be on chain yet.
+	require.Equal(parent.Hash, sys.L2EL.BlockRefByLabel(eth.Unsafe).Hash,
+		"head must not advance after the payload is dropped")
+	_, err := sys.L2EL.Escape().EthClient().TransactionReceipt(ctx, txHash)
+	require.Error(err, "dropped-payload tx must not be on chain before carryover")
+
+	// ── build#2 (carryover): a fresh build on the SAME parent H but with origin
+	// O2 (distinct attrs -> distinct payloadId -> a real new build_payload). Its
+	// carryover preamble re-dispatches the surviving Success entry from the fifo,
+	// and `ensure_only_one_payload` cancels build#1's now-abandoned reth job so
+	// build#2 is the sole live build. Use the granular Open->wait->Seal path — NOT
+	// Next(), which chains Open->Seal in ~µs, sealing before carryover (a state
+	// query + EVM execute) can run.
+	require.NoError(tsL2.New(ctx, seqtypes.BuildOpts{Parent: parent.Hash, L1Origin: &o2Hash}), "New build#2")
+	require.NoError(tsL2.Open(ctx), "Open build#2")
+	time.Sleep(600 * time.Millisecond)
+	require.NoError(tsL2.Seal(ctx), "Seal build#2")
+	require.NoError(tsL2.Sign(ctx), "Sign build#2")
+	require.NoError(tsL2.Commit(ctx), "Commit build#2")
+	require.NoError(tsL2.Publish(ctx), "Publish build#2")
+
+	// SLA: the commitment re-lands via carryover, same hash, exactly once, in the
+	// block right after H — and that block is genuinely build#2 (origin O2), which
+	// proves carryover ran a fresh build rather than the test vacuously reusing a
+	// cached build#1 payload.
+	rec := waitReceipt(t, sys.L2EL, txHash)
+	landed := sys.L2EL.BlockRefByNumber(rec.BlockNumber.Uint64())
+	require.Equal(rec.BlockHash, landed.Hash, "re-landed tx must be in the canonical chain")
+	require.Equal(parent.Number+1, landed.Number, "commitment must land in the block right after H")
+	require.Equalf(o2.Number, landed.L1Origin.Number,
+		"re-landed block must be build#2 (origin O2=%d), not a cached build#1 (origin O1=%d) — "+
+			"otherwise carryover was never exercised", o2.Number, o1.Number)
+	logger.Info("commitment re-landed via carryover after dropped payload",
+		"hash", txHash, "block", landed.Number, "l1Origin", landed.L1Origin.Number)
+}
+
+// sendPreconf submits a native-transfer preconf tx from `from` and asserts it
+// returns the success (must-land) commitment. It returns the tx hash.
+func sendPreconf(t devtest.T, ctx context.Context, el *dsl.L2ELNode, from *dsl.EOA, to common.Address, amount eth.ETH) common.Hash {
+	require := t.Require()
+	ptx := txplan.NewPlannedTx(from.PlanTransfer(to, amount))
+	signed, err := ptx.Signed.Eval(ctx)
+	require.NoError(err, "must sign preconf tx")
+	raw, err := signed.MarshalBinary()
+	require.NoError(err, "must RLP-encode signed tx")
+	txHash := signed.Hash()
+
+	var ev preconfEvent
+	require.NoError(
+		el.Escape().L2EthClient().RPC().CallContext(ctx, &ev,
+			"eth_sendRawTransactionWithPreconf", hexutil.Encode(raw)),
+		"preconf submission must not error")
+	require.Equalf("success", ev.Status,
+		"preconf must return success (the must-land commitment); reason=%q", ev.Reason)
+	require.Equal(txHash, ev.TxHash, "returned hash must match the submitted tx")
+	return txHash
+}
+
+// assertReLandedCanonical waits for hash to reappear on chain and asserts it
+// sits in exactly one canonical block (a tx hash can only be canonical in one
+// block, so this rejects orphaned or duplicate inclusion). It returns the
+// receipt.
+func assertReLandedCanonical(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	rec := waitReceipt(t, el, hash)
+	t.Require().Equal(hash, rec.TxHash, "same hash must re-land")
+	canon := el.BlockRefByNumber(rec.BlockNumber.Uint64())
+	t.Require().Equalf(rec.BlockHash, canon.Hash,
+		"re-landed tx %s must be in the canonical chain (no orphaned/duplicate inclusion)", hash)
+	return rec
+}
+
+// waitReverted blocks until ref is no longer the canonical block at its height
+// (hash changed, or the chain is momentarily shorter), i.e. the reorg reverted
+// it. attempts polls at 2s each.
+func waitReverted(t devtest.T, el *dsl.L2ELNode, ref eth.L2BlockRef, attempts int) {
+	t.Require().Eventuallyf(func() bool {
+		cur, err := el.Escape().EthClient().BlockRefByNumber(t.Ctx(), ref.Number)
+		if err != nil {
+			// "not found" means the chain is (transiently) shorter than the
+			// reverted height — the block is gone.
+			return true
+		}
+		return cur.Hash != ref.Hash
+	}, time.Duration(attempts)*2*time.Second, 2*time.Second,
+		"awaiting revert of L2 block %d (%s)", ref.Number, ref.Hash)
+}
+
+// waitReceipt polls the L2 EL until a receipt for hash is available.
+func waitReceipt(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	var rec *types.Receipt
+	t.Require().Eventuallyf(func() bool {
+		r, err := el.Escape().EthClient().TransactionReceipt(t.Ctx(), hash)
+		if err != nil || r == nil {
+			return false
+		}
+		rec = r
+		return true
+	}, 60*time.Second, 2*time.Second, "awaiting receipt for %s", hash)
+	return rec
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg/spike_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg/spike_test.go
@@ -1,0 +1,4 @@
+package reorg
+
+// (throwaway feasibility spikes removed; the shared helper moved to
+// helpers_test.go. This file is empty and can be deleted.)

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_nojournal/init_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_nojournal/init_test.go
@@ -1,0 +1,22 @@
+package reorgnojournal
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		// Same test-sequencer topology as the journal-on reorg package, but the
+		// preconf subsystem is started with the on-disk journal DISABLED. That is
+		// the whole point of TC-RG4: journal is a launch flag, not runtime
+		// toggleable, so the degraded path needs its own orchestrator (hence its
+		// own package / TestMain). Only op-reth honours preconf, so these tests
+		// require DEVSTACK_L2EL_KIND=op-reth and skip otherwise.
+		presets.WithNewMantleSingleChainMultiNodeWithTestSeqPreconfNoJournal(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithNoDiscovery(),
+	)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_nojournal/reorg_nojournal_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_nojournal/reorg_nojournal_test.go
@@ -1,0 +1,271 @@
+// Package reorgnojournal covers TC-RG4: a preconf reorg on a node running with
+// the commitment journal DISABLED (the degraded replay path).
+//
+// With the journal enabled (see the sibling `reorg` package, TC-RG2/RG3) a
+// reverted commitment is identified as a reorg replay and re-injected with the
+// SLA gate bypassed, so it MUST re-land. With the journal OFF that
+// identification is gone: reverted commitments fall back to a plain
+// FIFO-membership check and MAY be legitimately dropped. So this test is a
+// CHARACTERIZATION test, not a pass/fail must-land test — per the plan:
+//
+//	"逐笔如实记录重新上链情况——降级路径下部分承诺可能丢失（不上链即记录，不算
+//	 执行失败）；输出与 journal 开启场景（TC-RG2）的对照差异表。"
+//
+// What we hard-assert (invariants that must hold even on the degraded path):
+//   - a real reorg happened (the commitment block was reverted) — otherwise the
+//     whole measurement is vacuous;
+//   - for every commitment that DOES re-land, it lands exactly once on the
+//     canonical chain (no duplicate / orphaned inclusion);
+//   - the node stays alive and keeps producing blocks afterwards.
+//
+// What we DON'T assert (and must not, per the plan): that every commitment
+// re-lands. Instead we record the re-land / dropped tally and log it so the
+// loss ratio can be compared against journal-on (TC-RG2) and signed off with
+// the developer.
+//
+// The reorg is driven exactly as in the `reorg` package: an in-process test
+// sequencer rewrites an L1 block on an ancestor parent, and op-node cascades the
+// L1 reorg into an L2 unsafe reorg. Requires the sysgo orchestrator and op-reth.
+package reorgnojournal
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// preconfEvent mirrors mantle-reth's PreconfTxEvent serde (crates/rpc-ext).
+// The wire is camelCase (PreconfTxEvent derives serde(rename_all = "camelCase")),
+// so the keys are txHash / blockHeight — NOT snake_case (tagging them snake_case
+// silently decodes to zero). Duplicated from the `reorg` package.
+type preconfEvent struct {
+	TxHash      common.Hash    `json:"txHash"`
+	Status      string         `json:"status"`
+	Reason      string         `json:"reason"`
+	BlockHeight hexutil.Uint64 `json:"blockHeight"`
+}
+
+// TestPreconfReorgWithJournalDisabled (TC-RG4) submits several preconf
+// commitments, reorgs out the block(s) that carried them on a node whose
+// commitment journal is OFF, and records — per commitment — whether it re-landed
+// on the new canonical chain. It does NOT require every commitment to re-land;
+// it records the tally for the journal-on-vs-off contrast table.
+func TestPreconfReorgWithJournalDisabled(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Freeze the safe head so the blocks carrying the commitments stay unsafe —
+	// only unsafe blocks are reverted by the L1-origin rewrite below.
+	sys.L2Batcher.Stop()
+	gt.Cleanup(func() { sys.L2Batcher.Start() })
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+
+	// Fund all senders FIRST — while L1/L2 still advance freely (before we freeze L1
+	// below), so all 4 funding txs reliably get mined; and on an early L1 origin the
+	// later reorg will NOT revert (else they are unfunded at the new tip and the
+	// re-injected txs are rejected for insufficient funds, which would corrupt the
+	// journal-off drop measurement below). A fresh EOA per commitment keeps nonces
+	// independent.
+	const numCommitments = 4
+	// Fund sequentially (NOT NewFundedEOAs, which funds concurrently and races the
+	// single faucet account's nonce — flaky for count>1).
+	alices := make([]*dsl.EOA, numCommitments)
+	for i := range alices {
+		alices[i] = sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	}
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+	fundOrigin := sys.L2EL.BlockRefByLabel(eth.Unsafe).L1Origin.Number
+
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Advance L1 until the L2 unsafe head sits on an L1 origin past our start.
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	// Submit several commitments back-to-back so they land in the current unsafe
+	// block (nominal TC-RG4 shape: "多笔交易 + 1 块 revert"). We do NOT advance L1
+	// between them.
+	type commitment struct {
+		hash  common.Hash
+		block eth.L2BlockRef
+	}
+	commitments := make([]commitment, 0, numCommitments)
+	for i := range numCommitments {
+		h := sendPreconf(t, ctx, sys.L2EL, alices[i], bob.Address(), eth.OneHundredthEther)
+		rec := waitReceipt(t, sys.L2EL, h)
+		blk := sys.L2EL.BlockRefByNumber(rec.BlockNumber.Uint64())
+		require.NotZero(blk.L1Origin.Number, "commitment block must have a non-genesis L1 origin")
+		commitments = append(commitments, commitment{hash: h, block: blk})
+		logger.Info("commitment landed", "i", i, "hash", h, "l2", blk.Number, "l1Origin", blk.L1Origin.Number)
+	}
+
+	// Earliest commitment block — reverting its L1 origin reverts it and every
+	// descendant, so the whole commitment set goes even if they span >1 block.
+	earliest := commitments[0].block
+	for _, c := range commitments {
+		if c.block.Number < earliest.Number {
+			earliest = c.block
+		}
+	}
+
+	require.Greaterf(earliest.L1Origin.Number, fundOrigin,
+		"earliest commitment origin %d must exceed funding origin %d", earliest.L1Origin.Number, fundOrigin)
+
+	// Freeze the L2 head so the revert stays shallow (else deep-reorg churn would
+	// corrupt the journal-off re-land/drop measurement); resume once the L1 reorg
+	// has propagated past the old head so op-node applies the reset promptly.
+	oldL1Head := sys.L1EL.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2CL.StopSequencer()
+
+	// Trigger the reorg: rebuild the earliest commitment block's L1 origin on its
+	// parent, then resume so the alternate L1 chain wins.
+	l1Before := sys.L1EL.BlockRefByNumber(earliest.L1Origin.Number)
+	logger.Info("triggering L1 reorg (journal OFF)", "l1", l1Before, "revertFromL2", earliest.Number)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	require.Eventuallyf(func() bool {
+		h := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		return h.Number > oldL1Head &&
+			sys.L1EL.BlockRefByNumber(l1Before.Number).Hash != l1Before.Hash
+	}, 120*time.Second, 2*time.Second, "L1 reorg must propagate past old head %d", oldL1Head)
+	require.NotEqual(sys.L1EL.BlockRefByNumber(l1Before.Number).Hash, l1Before.Hash, "L1 must have reorged")
+	sys.L2CL.StartSequencer()
+
+	// Precondition: the earliest commitment block must actually be reverted,
+	// otherwise the re-land measurement below is vacuous.
+	waitReverted(t, sys.L2EL, earliest, 30)
+	logger.Info("L2 reorg triggered (journal OFF)", "revertedFrom", earliest.Number)
+
+	// Characterize: per commitment, record re-landed vs dropped. Do NOT fail on a
+	// drop — on the degraded path that is a legitimate (if unfortunate) outcome.
+	// For every one that DOES re-land, assert canonical uniqueness (no dup).
+	var reLanded, dropped int
+	for _, c := range commitments {
+		rec := pollReceipt(t, sys.L2EL, c.hash, 15) // ~30s tolerant poll; nil = not re-landed
+		if rec == nil {
+			dropped++
+			logger.Warn("commitment DROPPED after reorg (journal off)", "hash", c.hash, "origBlock", c.block.Number)
+			continue
+		}
+		reLanded++
+		canon := sys.L2EL.BlockRefByNumber(rec.BlockNumber.Uint64())
+		require.Equalf(rec.BlockHash, canon.Hash,
+			"re-landed tx %s must sit in the canonical chain (no orphaned/duplicate inclusion)", c.hash)
+		logger.Info("commitment re-landed after reorg (journal off)", "hash", c.hash,
+			"origBlock", c.block.Number, "newBlock", rec.BlockNumber)
+	}
+
+	// The contrast row for the TC-RG4 vs TC-RG2 diff table. Compare re-land ratio
+	// against the journal-on run and sign the acceptable loss off with the dev.
+	// TODO(TC-RG4): emit this as a machine-readable artifact (e.g. testlog / a
+	//   JSON line) so the journal-on vs journal-off table can be assembled in CI
+	//   rather than eyeballed from logs. Then decide with the developer whether a
+	//   max-acceptable-drop threshold should become a hard assertion here.
+	logger.Info("TC-RG4 result (journal OFF degraded path)",
+		"submitted", numCommitments, "reLanded", reLanded, "dropped", dropped)
+
+	// Liveness: whatever the replay outcome, the node must not have wedged.
+	beforeTip := sys.L2EL.BlockRefByLabel(eth.Unsafe).Number
+	require.Eventuallyf(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		return sys.L2EL.BlockRefByLabel(eth.Unsafe).Number > beforeTip
+	}, 60*time.Second, 2*time.Second, "node must keep producing blocks after the reorg")
+}
+
+// --- helpers (duplicated from the `reorg` package; keep in sync) ------------
+
+// sendPreconf submits a native-transfer preconf tx and asserts the success
+// (must-land) commitment. Returns the tx hash.
+func sendPreconf(t devtest.T, ctx context.Context, el *dsl.L2ELNode, from *dsl.EOA, to common.Address, amount eth.ETH) common.Hash {
+	require := t.Require()
+	ptx := txplan.NewPlannedTx(from.PlanTransfer(to, amount))
+	signed, err := ptx.Signed.Eval(ctx)
+	require.NoError(err, "must sign preconf tx")
+	raw, err := signed.MarshalBinary()
+	require.NoError(err, "must RLP-encode signed tx")
+	txHash := signed.Hash()
+
+	var ev preconfEvent
+	require.NoError(
+		el.Escape().L2EthClient().RPC().CallContext(ctx, &ev,
+			"eth_sendRawTransactionWithPreconf", hexutil.Encode(raw)),
+		"preconf submission must not error")
+	require.Equalf("success", ev.Status,
+		"preconf must return success (the must-land commitment); reason=%q", ev.Reason)
+	require.Equal(txHash, ev.TxHash, "returned hash must match the submitted tx")
+	return txHash
+}
+
+// waitReceipt polls until a receipt for hash is available (used for the INITIAL
+// landing, which must succeed).
+func waitReceipt(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	var rec *types.Receipt
+	t.Require().Eventuallyf(func() bool {
+		r, err := el.Escape().EthClient().TransactionReceipt(t.Ctx(), hash)
+		if err != nil || r == nil {
+			return false
+		}
+		rec = r
+		return true
+	}, 60*time.Second, 2*time.Second, "awaiting receipt for %s", hash)
+	return rec
+}
+
+// pollReceipt is the TOLERANT variant used AFTER the reorg: it returns the
+// receipt if the tx re-lands within `attempts` (2s each), or nil if it never
+// does. Unlike waitReceipt it does not fail the test on absence — a dropped
+// commitment is an expected outcome on the journal-off degraded path.
+func pollReceipt(t devtest.T, el *dsl.L2ELNode, hash common.Hash, attempts int) *types.Receipt {
+	for range attempts {
+		r, err := el.Escape().EthClient().TransactionReceipt(t.Ctx(), hash)
+		if err == nil && r != nil {
+			return r
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return nil
+}
+
+// waitReverted blocks until ref is no longer canonical at its height (reverted).
+func waitReverted(t devtest.T, el *dsl.L2ELNode, ref eth.L2BlockRef, attempts int) {
+	t.Require().Eventuallyf(func() bool {
+		cur, err := el.Escape().EthClient().BlockRefByNumber(t.Ctx(), ref.Number)
+		if err != nil {
+			return true // chain transiently shorter than the reverted height
+		}
+		return cur.Hash != ref.Hash
+	}, time.Duration(attempts)*2*time.Second, 2*time.Second,
+		"awaiting revert of L2 block %d (%s)", ref.Number, ref.Hash)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_ordering/init_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_ordering/init_test.go
@@ -1,0 +1,22 @@
+package reorgordering
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		// Same test-sequencer topology as the `reorg` package, but the preconf
+		// subsystem uses a RESTRICTED (from,to) whitelist instead of --preconf.all.
+		// That is what makes a non-whitelisted, tip-ordered pool tx possible, which
+		// the ordering-inversion attribution test needs. Journal is ON here.
+		// Only op-reth honours preconf, so these tests require
+		// DEVSTACK_L2EL_KIND=op-reth and skip otherwise.
+		presets.WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelist(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithNoDiscovery(),
+	)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_ordering/reinject_diag_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_ordering/reinject_diag_test.go
@@ -1,0 +1,106 @@
+// Diagnostic (step 1): isolate the batcher-stopped / unsafe-only-reorg variable
+// from the ordering tests' re-land failure.
+//
+// The ordering tests stop the batcher (to keep the commitment block UNSAFE so an
+// L1-origin rewrite can revert it). In those runs neither the preconf tx nor a
+// plain normal tx re-lands after the reorg — reth's stock pool re-injection never
+// fires (only the `reorg_drift` observe-warn). This test changes exactly ONE
+// thing: it leaves the batcher RUNNING and waits for the tx's block to become
+// SAFE before reverting its L1 origin, i.e. a SAFE reorg (op-node re-derives from
+// L1) instead of a pure unsafe reorg.
+//
+//   - If the plain tx re-lands here → reth's re-injection works on safe reorgs;
+//     the ordering-test failure is specific to the batcher-stopped/unsafe path
+//     (a harness artifact, acceptable — the tests just need a safe-reorg shape).
+//   - If it still does NOT re-land → reth's reorg re-injection is broken
+//     regardless (a real must-land-across-reorg gap), independent of preconf.
+//
+// It uses only a NON-whitelisted normal tx (pure reth pool path), so preconf is
+// not involved in the re-land — this isolates reth's native pool re-injection.
+package reorgordering
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestReinjectDiagNormalTxSafeReorg submits a single plain normal tx, waits for
+// its block to become SAFE (batcher left running), reorgs that block's L1 origin,
+// and asserts the tx re-lands. Pure reth pool path — no preconf involvement.
+func TestReinjectDiagNormalTxSafeReorg(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// NOTE: batcher is deliberately NOT stopped — that is the isolated variable.
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Advance L1 until the L2 SAFE head sits on an L1 origin past our start.
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Safe := sys.L2EL.BlockRefByLabel(eth.Safe)
+		return l2Safe.Number > 0 && l2Safe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	// Submit a plain normal tx (non-whitelisted recipient → pure pool path).
+	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	normTo := common.HexToAddress(normalRecipient)
+	txN := submitNormal(t, ctx, sys.L2EL, alice, normTo, eth.OneHundredthEther, highTipWei)
+	recN := waitReceipt(t, sys.L2EL, txN)
+	blkN := sys.L2EL.BlockRefByNumber(recN.BlockNumber.Uint64())
+	require.NotZero(blkN.L1Origin.Number, "tx block must have a non-genesis L1 origin")
+	logger.Info("normal tx landed (unsafe)", "block", blkN.Number, "l1Origin", blkN.L1Origin.Number)
+
+	// Keep advancing L1 (so the batcher can post + op-node can derive) until the
+	// tx's block becomes SAFE — only then is reverting its L1 origin a safe reorg.
+	require.Eventuallyf(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		return sys.L2EL.BlockRefByLabel(eth.Safe).Number >= blkN.Number
+	}, 180*time.Second, 2*time.Second, "tx block %d must become safe", blkN.Number)
+	logger.Info("tx block is now safe", "block", blkN.Number,
+		"safeHead", sys.L2EL.BlockRefByLabel(eth.Safe).Number)
+
+	// Reorg the tx block's L1 origin — a SAFE reorg (op-node re-derives).
+	l1Before := sys.L1EL.BlockRefByNumber(blkN.L1Origin.Number)
+	logger.Info("triggering L1 (safe) reorg", "l1", l1Before, "revertFromL2", blkN.Number)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	sys.L1EL.WaitForBlockNumber(l1Before.Number)
+	require.NotEqual(sys.L1EL.BlockRefByNumber(l1Before.Number).Hash, l1Before.Hash, "L1 must have reorged")
+
+	waitReverted(t, sys.L2EL, blkN, 30)
+	require.NotEqual(blkN.Hash, sys.L2EL.BlockRefByNumber(blkN.Number).Hash,
+		"the original tx block must no longer be canonical after the reorg")
+	logger.Info("L2 safe reorg triggered; tx block reverted", "reverted", blkN.Number)
+
+	// THE ISOLATION ASSERTION: does the reverted plain tx re-land? (reth pool
+	// re-injection on a safe reorg.)
+	reN := assertReLandedCanonical(t, sys.L2EL, txN)
+	logger.Info("DIAG RESULT: normal tx re-landed after SAFE reorg",
+		"hash", txN, "block", reN.BlockNumber, "idx", reN.TransactionIndex)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_ordering/reorg_ordering_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_ordering/reorg_ordering_test.go
@@ -1,0 +1,335 @@
+// Package reorgordering strengthens the TC-RG2 reorg attribution: it proves a
+// reverted preconf commitment re-lands via the PRECONF path (the carryover
+// preamble), not merely via reth's native pool re-injection.
+//
+// Why this is needed: the `reorg` package asserts a reverted commitment's
+// receipt reappears on the new chain. But that only proves the OUTCOME (on
+// chain), not the CAUSE. The tx under test is a plain transfer, and reth
+// natively re-injects reverted-block txs into the pool — so a simple transfer
+// would re-land via ordinary pool mechanics even if the preconf must-land
+// machinery were deleted. The re-land assertion can therefore pass vacuously.
+//
+// The discriminator (black-box, no log scraping): the preconf builder applies
+// carryover/replay entries in a preamble BEFORE the normal pool best-tx loop
+// (mantle-reth crates/preconf/src/builder/payload_builder.rs), and the preconf
+// FIFO is arrival-ordered, tip-AGNOSTIC. A normal pool tx is placed later, in
+// tip order. So we co-submit:
+//
+//   - P: a preconf tx with a LOW tip (whitelisted sender→recipient), and
+//   - N: a normal tx with a HIGH tip (non-whitelisted recipient → pool path),
+//
+// let a reorg revert the block carrying both, and assert that after the reorg P
+// is ordered AHEAD of the higher-tip N. Under pure pool ordering the higher-tip
+// N would win; P winning proves the carryover path placed it. This requires a
+// RESTRICTED (from,to) whitelist (see the whitelist preset) — under
+// --preconf.all every tx is preconf and there is no tip-ordered tx to contrast.
+//
+// The reorg is driven exactly as in the `reorg` package: an in-process test
+// sequencer rewrites an L1 block on an ancestor parent, and op-node cascades the
+// L1 reorg into an L2 unsafe reorg. Requires the sysgo orchestrator and op-reth.
+package reorgordering
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// preconfEvent decodes the subset of eth_sendRawTransactionWithPreconf's result
+// we assert on. The wire is camelCase (mantle-reth's PreconfTxEvent derives
+// serde(rename_all = "camelCase")), so the keys are txHash / blockHeight — NOT
+// snake_case (tagging them snake_case silently decodes to zero).
+type preconfEvent struct {
+	TxHash      common.Hash    `json:"txHash"`
+	Status      string         `json:"status"`
+	Reason      string         `json:"reason"`
+	BlockHeight hexutil.Uint64 `json:"blockHeight"`
+}
+
+// normalRecipient is a fixed address that is NOT in the preconf recipient
+// whitelist (sysgo.PreconfWhitelistRecipientAddr), so a transfer to it stays a
+// tip-ordered pool tx rather than becoming preconf-eligible.
+const normalRecipient = "0x00000000000000000000000000000000000000B2"
+
+// lowTipWei is the preconf tx's priority fee (the txplan default, 1 gwei);
+// highTipWei is the normal tx's — two orders of magnitude higher, so under pure
+// pool ordering the normal tx would be placed first.
+var (
+	lowTipWei  = big.NewInt(1e9)   // 1 gwei (matches txplan default)
+	highTipWei = big.NewInt(200e9) // 200 gwei
+)
+
+// TestPreconfReorgOrderingInversion (TC-RG2, attribution) co-submits a low-tip
+// preconf tx P and a high-tip normal tx N into the same unsafe block, reorgs
+// that block out, and asserts that after the reorg P is ordered AHEAD of N —
+// proving P re-landed via the preconf carryover path, not tip-ordered pool
+// re-injection.
+func TestPreconfReorgOrderingInversion(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Freeze the safe head so the block carrying P and N stays unsafe — only
+	// unsafe blocks are reverted by the L1-origin rewrite below.
+	sys.L2Batcher.Stop()
+	gt.Cleanup(func() { sys.L2Batcher.Start() })
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Fund the senders FIRST, on the current (early) L1 origin — BEFORE advancing
+	// L1 to the reorg origin. This is CRITICAL: the reorg reverts the block
+	// carrying P/N and everything on that L1 origin. If the senders' funding txs
+	// were on that same (reverted) origin, the senders would be unfunded at the
+	// new tip, and reth would (correctly) reject the re-injected P/N for
+	// insufficient funds — so they'd never re-land. Funding on an earlier origin
+	// keeps the senders funded across the reorg. The whitelisted preconf sender is
+	// a fixed key (its address is --preconf.from); the normal tx uses a dynamic EOA.
+	priv, err := crypto.HexToECDSA(sysgo.PreconfWhitelistSenderPrivHex)
+	require.NoError(err, "must parse whitelisted preconf sender key")
+	kpc := dsl.NewKey(t, priv).User(sys.L2EL)
+	require.Equalf(common.HexToAddress(sysgo.PreconfWhitelistSenderAddr), kpc.Address(),
+		"fixed preconf sender key must derive the whitelisted address")
+	sys.FunderL2.Fund(kpc, eth.OneTenthEther)
+	aliceN := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	fundOrigin := sys.L2EL.BlockRefByLabel(eth.Unsafe).L1Origin.Number
+	logger.Info("senders funded", "fundL1Origin", fundOrigin)
+
+	// Advance L1 until the L2 unsafe head sits on an L1 origin past our start —
+	// that (later) origin is what we later reorg, leaving the funding intact.
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	rpcTo := common.HexToAddress(sysgo.PreconfWhitelistRecipientAddr) // whitelisted → preconf
+	normTo := common.HexToAddress(normalRecipient)                    // not whitelisted → pool
+
+	// Submit P (preconf, low tip) then N (normal, high tip) back-to-back with NO
+	// L1 advance between them, so op-node's next build carries both in one unsafe
+	// block: P via the preconf FIFO, N via the pool.
+	txP := submitPreconf(t, ctx, sys.L2EL, kpc, rpcTo, eth.OneHundredthEther)
+	txN := submitNormal(t, ctx, sys.L2EL, aliceN, normTo, eth.OneHundredthEther, highTipWei)
+	logger.Info("submitted preconf P (low tip) and normal N (high tip)", "P", txP, "N", txN)
+
+	recP := waitReceipt(t, sys.L2EL, txP)
+	recN := waitReceipt(t, sys.L2EL, txN)
+	blkP := sys.L2EL.BlockRefByNumber(recP.BlockNumber.Uint64())
+	blkN := sys.L2EL.BlockRefByNumber(recN.BlockNumber.Uint64())
+	// Guard the invariant above: the reorg target origin must be strictly above
+	// the funding origin, else the senders lose their funding in the reorg.
+	require.Greaterf(blkP.L1Origin.Number, fundOrigin,
+		"P origin %d must exceed funding origin %d so the reorg keeps senders funded",
+		blkP.L1Origin.Number, fundOrigin)
+	require.Greaterf(blkN.L1Origin.Number, fundOrigin,
+		"N origin %d must exceed funding origin %d so the reorg keeps senders funded",
+		blkN.L1Origin.Number, fundOrigin)
+	require.NotZero(blkP.L1Origin.Number, "P's block must have a non-genesis L1 origin to reorg")
+	require.NotZero(blkN.L1Origin.Number, "N's block must have a non-genesis L1 origin to reorg")
+	logger.Info("P and N landed", "P.block", blkP.Number, "N.block", blkN.Number,
+		"P.idx", recP.TransactionIndex, "N.idx", recN.TransactionIndex)
+
+	earliest := blkP
+	if blkN.Number < earliest.Number {
+		earliest = blkN
+	}
+
+	// Freeze the L2 unsafe head before triggering the reorg. Otherwise op-node
+	// keeps sequencing (~2s/block) throughout the multi-second reorg-cascade
+	// window and piles blocks onto the commitment's L1 origin; reverting that
+	// origin then produces a DEEP reorg whose churn stops the committed tx from
+	// re-landing (empirically the deep-reorg run never re-lands P). With the
+	// sequencer stopped no blocks pile up, so the revert stays shallow.
+	oldL1Head := sys.L1EL.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2CL.StopSequencer()
+
+	// Reorg out the earliest of the two blocks' L1 origin; reverting it reverts
+	// that block (and any descendant), so both P and N go.
+	l1Before := sys.L1EL.BlockRefByNumber(earliest.L1Origin.Number)
+	logger.Info("triggering L1 reorg", "l1", l1Before, "revertFromL2", earliest.Number, "oldL1Head", oldL1Head)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	// Wait for the alternate L1 chain to OVERTAKE the old head (and the target
+	// height to actually carry a different block). Only then has op-node's L1 view
+	// reorged, so restarting the sequencer applies the reset promptly instead of
+	// free-running (and rebuilding a deep pile) for ~20s while L1 catches up — the
+	// bug that made an earlier StartSequencer re-create the deep reorg.
+	require.Eventuallyf(func() bool {
+		h := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		return h.Number > oldL1Head &&
+			sys.L1EL.BlockRefByNumber(l1Before.Number).Hash != l1Before.Hash
+	}, 120*time.Second, 2*time.Second, "L1 reorg must propagate past old head %d", oldL1Head)
+	logger.Info("L1 reorg propagated", "l1Head", sys.L1EL.BlockRefByLabel(eth.Unsafe).Number)
+
+	// Resume sequencing so op-node APPLIES the L1-reorg reset. A stopped sequencer
+	// receives the reset signal but aborts without reverting the unsafe head
+	// ("Sequencer encountered reset signal, aborting work"), so the revert only
+	// materialises once sequencing resumes — which then also re-lands P via the
+	// carryover path and N via the pool. The head was frozen throughout the reorg
+	// window, so the revert is shallow (no deep-reorg churn).
+	sys.L2CL.StartSequencer()
+
+	waitReverted(t, sys.L2EL, earliest, 30)
+	require.NotEqual(earliest.Hash, sys.L2EL.BlockRefByNumber(earliest.Number).Hash,
+		"the original block carrying P/N must no longer be canonical after the reorg")
+	logger.Info("L2 reorg triggered; block reverted", "reverted", earliest.Number)
+
+	// Both must re-land, each in exactly one canonical block.
+	reP := assertReLandedCanonical(t, sys.L2EL, txP)
+	reN := assertReLandedCanonical(t, sys.L2EL, txN)
+	logger.Info("re-landed after reorg",
+		"P.block", reP.BlockNumber, "P.idx", reP.TransactionIndex,
+		"N.block", reN.BlockNumber, "N.idx", reN.TransactionIndex)
+
+	// Attribution: P (low tip) must be ordered AHEAD of N (high tip) on the new
+	// chain. Compare canonically as (blockNumber, txIndex); P preceding N proves
+	// the carryover path placed P — under pure pool ordering the higher-tip N
+	// would come first. N-before-P would signal a carryover regression.
+	require.Truef(precedes(reP, reN),
+		"preconf P (tip=%s) must be ordered before normal N (tip=%s) after reorg, but got "+
+			"P=(block %d, idx %d) vs N=(block %d, idx %d) — re-land went through tip-ordered "+
+			"pool, not the preconf carryover path",
+		lowTipWei, highTipWei,
+		reP.BlockNumber.Uint64(), reP.TransactionIndex,
+		reN.BlockNumber.Uint64(), reN.TransactionIndex)
+
+	// When co-located in one block, the index inversion is the cleanest signal:
+	// P's index < N's index despite N's higher tip.
+	if reP.BlockNumber.Uint64() == reN.BlockNumber.Uint64() {
+		require.Lessf(reP.TransactionIndex, reN.TransactionIndex,
+			"in the shared re-land block %d, low-tip preconf P (idx %d) must precede high-tip "+
+				"normal N (idx %d)", reP.BlockNumber.Uint64(), reP.TransactionIndex, reN.TransactionIndex)
+		logger.Info("clean in-block ordering inversion confirmed",
+			"block", reP.BlockNumber, "P.idx", reP.TransactionIndex, "N.idx", reN.TransactionIndex)
+	} else {
+		logger.Info("P and N re-landed in different blocks; canonical ordering still preconf-first",
+			"P.block", reP.BlockNumber, "N.block", reN.BlockNumber)
+	}
+}
+
+// precedes reports whether receipt a is canonically ordered before b, comparing
+// (blockNumber, transactionIndex) lexicographically.
+func precedes(a, b *types.Receipt) bool {
+	if c := a.BlockNumber.Cmp(b.BlockNumber); c != 0 {
+		return c < 0
+	}
+	return a.TransactionIndex < b.TransactionIndex
+}
+
+// --- submission helpers ------------------------------------------------------
+
+// signedTransfer builds a signed native-transfer tx from `from` to `to` for
+// `amount`, applying any extra txplan options (e.g. a tip override). It returns
+// the RLP-encoded raw bytes and the tx hash.
+func signedTransfer(t devtest.T, ctx context.Context, from *dsl.EOA, to common.Address, amount eth.ETH, opts ...txplan.Option) ([]byte, common.Hash) {
+	require := t.Require()
+	planOpts := append([]txplan.Option{from.PlanTransfer(to, amount)}, opts...)
+	ptx := txplan.NewPlannedTx(txplan.Combine(planOpts...))
+	signed, err := ptx.Signed.Eval(ctx)
+	require.NoError(err, "must sign tx")
+	raw, err := signed.MarshalBinary()
+	require.NoError(err, "must RLP-encode signed tx")
+	return raw, signed.Hash()
+}
+
+// submitPreconf submits a preconf tx (default 1 gwei tip) via
+// eth_sendRawTransactionWithPreconf and asserts the success (must-land)
+// commitment. Returns the tx hash.
+func submitPreconf(t devtest.T, ctx context.Context, el *dsl.L2ELNode, from *dsl.EOA, to common.Address, amount eth.ETH) common.Hash {
+	require := t.Require()
+	raw, txHash := signedTransfer(t, ctx, from, to, amount)
+	var ev preconfEvent
+	require.NoError(
+		el.Escape().L2EthClient().RPC().CallContext(ctx, &ev,
+			"eth_sendRawTransactionWithPreconf", hexutil.Encode(raw)),
+		"preconf submission must not error")
+	require.Equalf("success", ev.Status,
+		"preconf must return success (the must-land commitment); reason=%q", ev.Reason)
+	require.Equal(txHash, ev.TxHash, "returned hash must match the submitted tx")
+	return txHash
+}
+
+// submitNormal submits a plain tx (with an explicit priority-fee tip) via
+// eth_sendRawTransaction — the tip-ordered pool path. The recipient must NOT be
+// preconf-whitelisted, else the pool listener would mirror it into the FIFO.
+func submitNormal(t devtest.T, ctx context.Context, el *dsl.L2ELNode, from *dsl.EOA, to common.Address, amount eth.ETH, tip *big.Int) common.Hash {
+	require := t.Require()
+	raw, txHash := signedTransfer(t, ctx, from, to, amount, txplan.WithGasTipCap(tip))
+	var res common.Hash
+	require.NoError(
+		el.Escape().L2EthClient().RPC().CallContext(ctx, &res,
+			"eth_sendRawTransaction", hexutil.Encode(raw)),
+		"normal tx submission must not error")
+	return txHash
+}
+
+// --- shared assertion/poll helpers (kept in sync with the `reorg` package) ---
+
+// assertReLandedCanonical waits for hash to reappear on chain and asserts it sits
+// in exactly one canonical block (a tx hash is canonical in at most one block, so
+// this rejects orphaned/duplicate inclusion). Returns the receipt.
+func assertReLandedCanonical(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	rec := waitReceipt(t, el, hash)
+	t.Require().Equal(hash, rec.TxHash, "same hash must re-land")
+	canon := el.BlockRefByNumber(rec.BlockNumber.Uint64())
+	t.Require().Equalf(rec.BlockHash, canon.Hash,
+		"re-landed tx %s must be in the canonical chain (no orphaned/duplicate inclusion)", hash)
+	return rec
+}
+
+// waitReceipt polls the L2 EL until a receipt for hash is available.
+func waitReceipt(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	var rec *types.Receipt
+	t.Require().Eventuallyf(func() bool {
+		r, err := el.Escape().EthClient().TransactionReceipt(t.Ctx(), hash)
+		if err != nil || r == nil {
+			return false
+		}
+		rec = r
+		return true
+	}, 60*time.Second, 2*time.Second, "awaiting receipt for %s", hash)
+	return rec
+}
+
+// waitReverted blocks until ref is no longer the canonical block at its height
+// (hash changed, or the chain is momentarily shorter), i.e. the reorg reverted it.
+func waitReverted(t devtest.T, el *dsl.L2ELNode, ref eth.L2BlockRef, attempts int) {
+	t.Require().Eventuallyf(func() bool {
+		cur, err := el.Escape().EthClient().BlockRefByNumber(t.Ctx(), ref.Number)
+		if err != nil {
+			return true // chain transiently shorter than the reverted height
+		}
+		return cur.Hash != ref.Hash
+	}, time.Duration(attempts)*2*time.Second, 2*time.Second,
+		"awaiting revert of L2 block %d (%s)", ref.Number, ref.Hash)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_ordering_nojournal/init_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_ordering_nojournal/init_test.go
@@ -1,0 +1,22 @@
+package reorgorderingnojournal
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		// Restricted-whitelist test-sequencer topology (so a tip-ordered pool tx
+		// exists) with the preconf commitment journal DISABLED — the TC-RG4
+		// degraded path. Journal is a launch flag, not runtime toggleable, so the
+		// journal-off ordering characterization needs its own orchestrator / package.
+		// Only op-reth honours preconf, so these tests require
+		// DEVSTACK_L2EL_KIND=op-reth and skip otherwise.
+		presets.WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistNoJournal(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithNoDiscovery(),
+	)
+}

--- a/op-acceptance-tests/mantle-tests/preconf/reorg_ordering_nojournal/reorg_ordering_nojournal_test.go
+++ b/op-acceptance-tests/mantle-tests/preconf/reorg_ordering_nojournal/reorg_ordering_nojournal_test.go
@@ -1,0 +1,283 @@
+// Package reorgorderingnojournal is the journal-OFF (TC-RG4 degraded path)
+// counterpart of the `reorg_ordering` package.
+//
+// With the journal ON (see `reorg_ordering`, TC-RG2) a reverted preconf
+// commitment is identified as a reorg replay and re-dispatched through the
+// carryover preamble, so it re-lands AHEAD of a higher-tip normal tx — a clean
+// attribution signal. With the journal OFF that identification is gone: the
+// re-injected commitment is pushed as an Rpc-source entry subject to the SLA /
+// gas gates, so it MAY not get front-of-block carryover treatment, or may be
+// legitimately dropped. So this is a CHARACTERIZATION test, mirroring the
+// `reorg_nojournal` convention:
+//
+// Hard-asserted invariants (must hold even on the degraded path):
+//   - a real reorg happened (the block carrying P and N was reverted);
+//   - the high-tip normal tx N re-lands exactly once on the canonical chain;
+//   - the node stays alive and keeps producing blocks.
+//
+// Characterized (recorded, not required): whether the low-tip preconf tx P
+// re-lands at all, whether it co-locates with N, and its ordering. The ONLY
+// conditional invariant asserted about P: if it re-lands in the same block as N,
+// it must still precede N (a tip-order inversion the other way — high-tip N
+// before low-tip P in the same block — would be normal pool behaviour and is the
+// expected degraded outcome, so different blocks / a drop are NOT failures).
+package reorgorderingnojournal
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// preconfEvent mirrors mantle-reth's PreconfTxEvent serde (camelCase wire).
+type preconfEvent struct {
+	TxHash      common.Hash    `json:"txHash"`
+	Status      string         `json:"status"`
+	Reason      string         `json:"reason"`
+	BlockHeight hexutil.Uint64 `json:"blockHeight"`
+}
+
+const normalRecipient = "0x00000000000000000000000000000000000000B2"
+
+// highTipWei is the normal tx's priority fee — far above the preconf tx's
+// default 1 gwei, so under pure pool ordering the normal tx would be placed first.
+var highTipWei = big.NewInt(200e9) // 200 gwei
+
+// TestPreconfReorgOrderingInversionJournalOff (TC-RG4, characterization) runs the
+// same low-tip-preconf-vs-high-tip-normal ordering probe as `reorg_ordering` but
+// on a journal-OFF node, and records P's fate/ordering instead of hard-asserting
+// the inversion.
+func TestPreconfReorgOrderingInversionJournalOff(gt *testing.T) {
+	if os.Getenv("DEVSTACK_L2EL_KIND") != "op-reth" {
+		gt.Skip("preconf is only wired for op-reth; set DEVSTACK_L2EL_KIND=op-reth")
+	}
+
+	t := devtest.SerialT(gt)
+	sys := presets.NewMantleSingleChainMultiNodeWithTestSeq(t)
+	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	sys.L2Batcher.Stop()
+	gt.Cleanup(func() { sys.L2Batcher.Start() })
+
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.L1Network.WaitForBlock()
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	// Fund the senders FIRST, on the current (early) L1 origin — BEFORE advancing
+	// to the reorg origin — so their funding is NOT reverted by the reorg;
+	// otherwise the senders would be unfunded at the new tip and the re-injected
+	// txs would be rejected for insufficient funds (never re-landing).
+	priv, err := crypto.HexToECDSA(sysgo.PreconfWhitelistSenderPrivHex)
+	require.NoError(err, "must parse whitelisted preconf sender key")
+	kpc := dsl.NewKey(t, priv).User(sys.L2EL)
+	require.Equalf(common.HexToAddress(sysgo.PreconfWhitelistSenderAddr), kpc.Address(),
+		"fixed preconf sender key must derive the whitelisted address")
+	sys.FunderL2.Fund(kpc, eth.OneTenthEther)
+	aliceN := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+	fundOrigin := sys.L2EL.BlockRefByLabel(eth.Unsafe).L1Origin.Number
+
+	startL1Block := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	require.Eventually(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		l2Unsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
+	}, 120*time.Second, 2*time.Second)
+
+	rpcTo := common.HexToAddress(sysgo.PreconfWhitelistRecipientAddr)
+	normTo := common.HexToAddress(normalRecipient)
+
+	txP := submitPreconf(t, ctx, sys.L2EL, kpc, rpcTo, eth.OneHundredthEther)
+	txN := submitNormal(t, ctx, sys.L2EL, aliceN, normTo, eth.OneHundredthEther, highTipWei)
+	logger.Info("submitted preconf P (low tip) and normal N (high tip)", "P", txP, "N", txN)
+
+	recP := waitReceipt(t, sys.L2EL, txP)
+	recN := waitReceipt(t, sys.L2EL, txN)
+	blkP := sys.L2EL.BlockRefByNumber(recP.BlockNumber.Uint64())
+	blkN := sys.L2EL.BlockRefByNumber(recN.BlockNumber.Uint64())
+	require.NotZero(blkP.L1Origin.Number, "P's block must have a non-genesis L1 origin to reorg")
+	require.NotZero(blkN.L1Origin.Number, "N's block must have a non-genesis L1 origin to reorg")
+	require.Greaterf(blkN.L1Origin.Number, fundOrigin,
+		"N origin %d must exceed funding origin %d so the reorg keeps senders funded",
+		blkN.L1Origin.Number, fundOrigin)
+
+	earliest := blkP
+	if blkN.Number < earliest.Number {
+		earliest = blkN
+	}
+
+	// Freeze the L2 head so it does not run ahead during the reorg window (keeps
+	// the revert shallow), then resume once the L1 reorg has propagated so op-node
+	// applies the reset. See the journal-on ordering test for the full rationale.
+	oldL1Head := sys.L1EL.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2CL.StopSequencer()
+
+	l1Before := sys.L1EL.BlockRefByNumber(earliest.L1Origin.Number)
+	logger.Info("triggering L1 reorg (journal OFF)", "l1", l1Before, "revertFromL2", earliest.Number)
+	require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: l1Before.ParentHash}))
+	require.NoError(ts.Next(ctx))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	require.Eventuallyf(func() bool {
+		h := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+		return h.Number > oldL1Head &&
+			sys.L1EL.BlockRefByNumber(l1Before.Number).Hash != l1Before.Hash
+	}, 120*time.Second, 2*time.Second, "L1 reorg must propagate past old head %d", oldL1Head)
+	require.NotEqual(sys.L1EL.BlockRefByNumber(l1Before.Number).Hash, l1Before.Hash, "L1 must have reorged")
+	sys.L2CL.StartSequencer()
+
+	// Hard invariant: a real reorg happened.
+	waitReverted(t, sys.L2EL, earliest, 30)
+	require.NotEqual(earliest.Hash, sys.L2EL.BlockRefByNumber(earliest.Number).Hash,
+		"the original block carrying P/N must no longer be canonical after the reorg")
+	logger.Info("L2 reorg triggered (journal OFF)", "reverted", earliest.Number)
+
+	// Hard invariant: the normal tx N re-lands exactly once (native pool
+	// re-injection does not depend on the preconf journal).
+	reN := assertReLandedCanonical(t, sys.L2EL, txN)
+
+	// Characterize P: it MAY drop or land late on the degraded path.
+	reP := pollReceipt(t, sys.L2EL, txP, 15) // ~30s tolerant poll; nil = not re-landed
+	switch {
+	case reP == nil:
+		logger.Warn("TC-RG4: preconf P DROPPED after reorg (journal off, expected-possible)",
+			"P", txP, "N.reland.block", reN.BlockNumber)
+	default:
+		canon := sys.L2EL.BlockRefByNumber(reP.BlockNumber.Uint64())
+		require.Equalf(reP.BlockHash, canon.Hash,
+			"re-landed preconf P %s must sit in the canonical chain (no orphaned/duplicate inclusion)", txP)
+		sameBlock := reP.BlockNumber.Uint64() == reN.BlockNumber.Uint64()
+		if sameBlock {
+			// The only conditional invariant: co-located, P must still precede N.
+			require.Lessf(reP.TransactionIndex, reN.TransactionIndex,
+				"journal-off: when P re-lands in N's block %d, low-tip P (idx %d) must still "+
+					"precede high-tip N (idx %d)", reP.BlockNumber.Uint64(), reP.TransactionIndex, reN.TransactionIndex)
+		}
+		logger.Info("TC-RG4: preconf P re-landed (journal off)",
+			"P.block", reP.BlockNumber, "P.idx", reP.TransactionIndex,
+			"N.block", reN.BlockNumber, "N.idx", reN.TransactionIndex,
+			"sameBlockAsN", sameBlock, "preconfFirstWhenColocated", sameBlock)
+	}
+
+	// The contrast row for the TC-RG4 vs TC-RG2 diff table.
+	// TODO(TC-RG4): emit as a machine-readable artifact so the journal-on vs -off
+	//   ordering table can be assembled in CI rather than eyeballed from logs.
+	logger.Info("TC-RG4 ordering result (journal OFF degraded path)",
+		"preconfReLanded", reP != nil,
+		"coLocatedWithNormal", reP != nil && reN != nil && reP.BlockNumber.Uint64() == reN.BlockNumber.Uint64())
+
+	// Liveness: whatever the replay outcome, the node must not have wedged.
+	beforeTip := sys.L2EL.BlockRefByLabel(eth.Unsafe).Number
+	require.Eventuallyf(func() bool {
+		require.NoError(ts.New(ctx, seqtypes.BuildOpts{Parent: common.Hash{}}))
+		require.NoError(ts.Next(ctx))
+		return sys.L2EL.BlockRefByLabel(eth.Unsafe).Number > beforeTip
+	}, 60*time.Second, 2*time.Second, "node must keep producing blocks after the reorg")
+}
+
+// --- submission helpers (duplicated from reorg_ordering; keep in sync) --------
+
+func signedTransfer(t devtest.T, ctx context.Context, from *dsl.EOA, to common.Address, amount eth.ETH, opts ...txplan.Option) ([]byte, common.Hash) {
+	require := t.Require()
+	planOpts := append([]txplan.Option{from.PlanTransfer(to, amount)}, opts...)
+	ptx := txplan.NewPlannedTx(txplan.Combine(planOpts...))
+	signed, err := ptx.Signed.Eval(ctx)
+	require.NoError(err, "must sign tx")
+	raw, err := signed.MarshalBinary()
+	require.NoError(err, "must RLP-encode signed tx")
+	return raw, signed.Hash()
+}
+
+func submitPreconf(t devtest.T, ctx context.Context, el *dsl.L2ELNode, from *dsl.EOA, to common.Address, amount eth.ETH) common.Hash {
+	require := t.Require()
+	raw, txHash := signedTransfer(t, ctx, from, to, amount)
+	var ev preconfEvent
+	require.NoError(
+		el.Escape().L2EthClient().RPC().CallContext(ctx, &ev,
+			"eth_sendRawTransactionWithPreconf", hexutil.Encode(raw)),
+		"preconf submission must not error")
+	require.Equalf("success", ev.Status,
+		"preconf must return success (the must-land commitment); reason=%q", ev.Reason)
+	require.Equal(txHash, ev.TxHash, "returned hash must match the submitted tx")
+	return txHash
+}
+
+func submitNormal(t devtest.T, ctx context.Context, el *dsl.L2ELNode, from *dsl.EOA, to common.Address, amount eth.ETH, tip *big.Int) common.Hash {
+	require := t.Require()
+	raw, txHash := signedTransfer(t, ctx, from, to, amount, txplan.WithGasTipCap(tip))
+	var res common.Hash
+	require.NoError(
+		el.Escape().L2EthClient().RPC().CallContext(ctx, &res,
+			"eth_sendRawTransaction", hexutil.Encode(raw)),
+		"normal tx submission must not error")
+	return txHash
+}
+
+// --- shared assertion/poll helpers (kept in sync with the `reorg` package) ---
+
+func assertReLandedCanonical(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	rec := waitReceipt(t, el, hash)
+	t.Require().Equal(hash, rec.TxHash, "same hash must re-land")
+	canon := el.BlockRefByNumber(rec.BlockNumber.Uint64())
+	t.Require().Equalf(rec.BlockHash, canon.Hash,
+		"re-landed tx %s must be in the canonical chain (no orphaned/duplicate inclusion)", hash)
+	return rec
+}
+
+func waitReceipt(t devtest.T, el *dsl.L2ELNode, hash common.Hash) *types.Receipt {
+	var rec *types.Receipt
+	t.Require().Eventuallyf(func() bool {
+		r, err := el.Escape().EthClient().TransactionReceipt(t.Ctx(), hash)
+		if err != nil || r == nil {
+			return false
+		}
+		rec = r
+		return true
+	}, 60*time.Second, 2*time.Second, "awaiting receipt for %s", hash)
+	return rec
+}
+
+// pollReceipt is the TOLERANT variant used AFTER the reorg for P: it returns the
+// receipt if the tx re-lands within `attempts` (2s each), or nil if it never
+// does. A dropped commitment is an expected outcome on the journal-off path.
+func pollReceipt(t devtest.T, el *dsl.L2ELNode, hash common.Hash, attempts int) *types.Receipt {
+	for range attempts {
+		r, err := el.Escape().EthClient().TransactionReceipt(t.Ctx(), hash)
+		if err == nil && r != nil {
+			return r
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return nil
+}
+
+func waitReverted(t devtest.T, el *dsl.L2ELNode, ref eth.L2BlockRef, attempts int) {
+	t.Require().Eventuallyf(func() bool {
+		cur, err := el.Escape().EthClient().BlockRefByNumber(t.Ctx(), ref.Number)
+		if err != nil {
+			return true // chain transiently shorter than the reverted height
+		}
+		return cur.Hash != ref.Hash
+	}, time.Duration(attempts)*2*time.Second, 2*time.Second,
+		"awaiting revert of L2 block %d (%s)", ref.Number, ref.Hash)
+}

--- a/op-devstack/presets/mantle_singlechain_multinode.go
+++ b/op-devstack/presets/mantle_singlechain_multinode.go
@@ -94,3 +94,39 @@ func NewMantleSingleChainMultiNodeWithTestSeq(t devtest.T) *MantleSingleChainMul
 func WithNewMantleSingleChainMultiNodeWithTestSeq() stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqSystem(&sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs{}))
 }
+
+// WithNewMantleSingleChainMultiNodeWithTestSeqPreconf is the same topology as
+// WithNewMantleSingleChainMultiNodeWithTestSeq but with the Mantle preconf
+// subsystem enabled on the L2 EL(s). Hydrate it with
+// NewMantleSingleChainMultiNodeWithTestSeq. Intended to run under
+// DEVSTACK_L2EL_KIND=op-reth (only op-reth honours preconf).
+func WithNewMantleSingleChainMultiNodeWithTestSeqPreconf() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqPreconfSystem(&sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs{}))
+}
+
+// WithNewMantleSingleChainMultiNodeWithTestSeqPreconfNoJournal is like
+// WithNewMantleSingleChainMultiNodeWithTestSeqPreconf but starts preconf with
+// the on-disk commitment journal DISABLED, for the TC-RG4 degraded-path reorg
+// test (reorg-reverted commitments may be dropped rather than replayed).
+// Hydrate it with NewMantleSingleChainMultiNodeWithTestSeq, and run under
+// DEVSTACK_L2EL_KIND=op-reth.
+func WithNewMantleSingleChainMultiNodeWithTestSeqPreconfNoJournal() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqPreconfNoJournalSystem(&sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs{}))
+}
+
+// WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelist is the preconf
+// journal-ON test-seq topology but with a RESTRICTED (from,to) whitelist (vs
+// all=true), so a non-whitelisted, tip-ordered pool tx can be co-submitted. Used
+// by the journal-on ordering-inversion reorg test. Hydrate it with
+// NewMantleSingleChainMultiNodeWithTestSeq, run under DEVSTACK_L2EL_KIND=op-reth.
+// The whitelisted (sender,recipient) pair is sysgo.PreconfWhitelist{Sender,Recipient}Addr.
+func WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelist() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistSystem(&sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs{}))
+}
+
+// WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistNoJournal is the
+// journal-OFF counterpart of WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelist,
+// for the TC-RG4 degraded-path ordering characterization.
+func WithNewMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistNoJournal() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistNoJournalSystem(&sysgo.DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs{}))
+}

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -22,6 +22,17 @@ type L2ELConfig struct {
 	P2PNodeKeyHex string
 	StaticPeers   []string
 	TrustedPeers  []string
+
+	// Preconf configures the Mantle preconfirmation subsystem. It is only
+	// honoured by the op-reth EL (WithOpReth translates it into --preconf.*
+	// CLI flags); the op-geth EL ignores it. All-zero means preconf stays
+	// disabled, matching op-reth's default.
+	PreconfEnabled   bool
+	PreconfAll       bool     // --preconf.all: every tx is preconf-eligible (skip whitelist)
+	PreconfFrom      []string // --preconf.from: sender whitelist (unused when PreconfAll)
+	PreconfTo        []string // --preconf.to: recipient whitelist (unused when PreconfAll)
+	PreconfJournal   bool     // enable the on-disk journal (path chosen under the node tempdir)
+	PreconfTimeoutMs int      // --preconf.timeout-ms; 0 = leave op-reth's default
 }
 
 func L2ELWithSupervisor(supervisorID stack.SupervisorID) L2ELOption {
@@ -38,6 +49,22 @@ func L2ELWithP2PConfig(addr string, port int, nodeKeyHex string, staticPeers, tr
 		cfg.P2PNodeKeyHex = nodeKeyHex
 		cfg.StaticPeers = staticPeers
 		cfg.TrustedPeers = trustedPeers
+	})
+}
+
+// L2ELWithPreconf enables the Mantle preconf subsystem on the L2 EL. Only the
+// op-reth EL honours this (op-geth ignores it). Pass all=true to skip the
+// (from,to) whitelist, or supply from/to lists otherwise. journal=true enables
+// the on-disk commitment journal (needed to exercise the reorg/restart replay
+// paths). timeoutMs<=0 leaves op-reth's default RPC deadline.
+func L2ELWithPreconf(all, journal bool, from, to []string, timeoutMs int) L2ELOption {
+	return L2ELOptionFn(func(p devtest.P, id stack.L2ELNodeID, cfg *L2ELConfig) {
+		cfg.PreconfEnabled = true
+		cfg.PreconfAll = all
+		cfg.PreconfFrom = from
+		cfg.PreconfTo = to
+		cfg.PreconfJournal = journal
+		cfg.PreconfTimeoutMs = timeoutMs
 	})
 }
 

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -293,6 +293,29 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 			args = append(args, "--rollup.supervisor-http="+supervisorRPC)
 		}
 
+		// Mantle preconf subsystem. reth has no env-var config, so these are
+		// CLI flags (names per mantle-reth/crates/cli/src/args.rs). The journal
+		// file lives under tempDir, alongside genesis/logs above.
+		if cfg.PreconfEnabled {
+			args = append(args, "--preconf.enable")
+			if cfg.PreconfAll {
+				args = append(args, "--preconf.all")
+			}
+			for _, a := range cfg.PreconfFrom {
+				args = append(args, "--preconf.from="+a)
+			}
+			for _, a := range cfg.PreconfTo {
+				args = append(args, "--preconf.to="+a)
+			}
+			if cfg.PreconfJournal {
+				journalPath := filepath.Join(tempDir, "preconf.journal")
+				args = append(args, "--preconf.journal-path="+journalPath)
+			}
+			if cfg.PreconfTimeoutMs > 0 {
+				args = append(args, fmt.Sprintf("--preconf.timeout-ms=%d", cfg.PreconfTimeoutMs))
+			}
+		}
+
 		l2EL := &OpReth{
 			id:                 id,
 			jwtPath:            jwtPath,

--- a/op-devstack/sysgo/mantle_system_singlechain_multinode.go
+++ b/op-devstack/sysgo/mantle_system_singlechain_multinode.go
@@ -66,6 +66,102 @@ func DefaultMantleSingleChainMultiNodeWithTestSeqSystem(dest *DefaultMantleSingl
 	return opt
 }
 
+// DefaultMantleSingleChainMultiNodeWithTestSeqPreconfSystem is the Mantle
+// test-sequencer topology with the preconf subsystem enabled on every L2 EL.
+// Preconf is turned on via a global L2EL option applied before deploy, so it
+// covers the sequencer EL (wired inside DefaultMantleMinimalSystem) as well as
+// the verifier. Only the op-reth EL honours preconf, so this system is meant
+// to be run with DEVSTACK_L2EL_KIND=op-reth; under op-geth the flags are
+// ignored and the topology behaves like the non-preconf variant.
+func DefaultMantleSingleChainMultiNodeWithTestSeqPreconfSystem(dest *DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs) stack.Option[*Orchestrator] {
+	opt := stack.Combine[*Orchestrator]()
+	// all=true (skip whitelist, no need to know the test EOA at launch) +
+	// journal=true (exercise the commitment-replay path across a reorg).
+	opt.Add(WithGlobalL2ELOption(L2ELWithPreconf(true, true, nil, nil, 0)))
+	opt.Add(DefaultMantleSingleChainMultiNodeWithTestSeqSystem(dest))
+	return opt
+}
+
+// DefaultMantleSingleChainMultiNodeWithTestSeqPreconfNoJournalSystem mirrors
+// DefaultMantleSingleChainMultiNodeWithTestSeqPreconfSystem but launches the
+// preconf subsystem with the on-disk commitment journal DISABLED
+// (journal=false). It exists to exercise the TC-RG4 "reorg + journal off"
+// degraded path: without the journal, a reorg-reverted commitment is only
+// re-injected via a plain FIFO-membership check (no Replay identification), so
+// some commitments MAY be legitimately dropped instead of replayed. As with the
+// journal-on variant, only op-reth honours the flags.
+func DefaultMantleSingleChainMultiNodeWithTestSeqPreconfNoJournalSystem(dest *DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs) stack.Option[*Orchestrator] {
+	opt := stack.Combine[*Orchestrator]()
+	// all=true (skip whitelist, no need to know the test EOA at launch) +
+	// journal=false (degraded replay path — the whole point of TC-RG4).
+	opt.Add(WithGlobalL2ELOption(L2ELWithPreconf(true, false, nil, nil, 0)))
+	opt.Add(DefaultMantleSingleChainMultiNodeWithTestSeqSystem(dest))
+	return opt
+}
+
+// Fixed identities baked into the RESTRICTED-whitelist preconf systems below.
+//
+// The ordering-inversion reorg tests (preconf/reorg_ordering*) need a
+// tip-ordered NON-preconf tx to contrast against, which the `all=true` systems
+// above cannot provide (under --preconf.all every tx is preconf). With a
+// restricted whitelist `is_preconf_tx` requires BOTH from AND to to match
+// (crates/preconf/src/config.rs), and the whitelist is a launch flag — so the
+// eligible (sender,recipient) pair must be known before the node starts. These
+// fixed values are that pair; the test signs the preconf tx with
+// PreconfWhitelistSenderPrivHex (whose address is PreconfWhitelistSenderAddr)
+// and sends it to PreconfWhitelistRecipientAddr. A normal tx to any OTHER
+// recipient is not preconf-eligible and stays in the tip-ordered pool.
+//
+// The sender key is a well-known dev key (Anvil account #2). The devstack HD
+// wallet uses a fresh RANDOM mnemonic per run, so this fixed address cannot
+// collide with the funder-derived accounts.
+const (
+	// PreconfWhitelistSenderPrivHex is the private key (no 0x prefix) of the
+	// whitelisted preconf sender; the test loads it to sign the preconf tx.
+	PreconfWhitelistSenderPrivHex = "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+	// PreconfWhitelistSenderAddr is the address of PreconfWhitelistSenderPrivHex,
+	// passed as --preconf.from.
+	PreconfWhitelistSenderAddr = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+	// PreconfWhitelistRecipientAddr is the whitelisted preconf recipient,
+	// passed as --preconf.to. No private key is needed — it is only a transfer
+	// target.
+	PreconfWhitelistRecipientAddr = "0x00000000000000000000000000000000000000A1"
+)
+
+// DefaultMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistSystem mirrors the
+// preconf journal-ON system but with a RESTRICTED (from,to) whitelist instead of
+// all=true, so a non-whitelisted tx exists as a tip-ordered pool tx. Used by the
+// journal-on ordering-inversion reorg test to prove a reverted preconf tx
+// re-lands via the carryover path (ahead of a higher-tip normal tx) rather than
+// via reth-native pool re-injection. Only op-reth honours the flags.
+func DefaultMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistSystem(dest *DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs) stack.Option[*Orchestrator] {
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(WithGlobalL2ELOption(L2ELWithPreconf(
+		false, true,
+		[]string{PreconfWhitelistSenderAddr},
+		[]string{PreconfWhitelistRecipientAddr},
+		0,
+	)))
+	opt.Add(DefaultMantleSingleChainMultiNodeWithTestSeqSystem(dest))
+	return opt
+}
+
+// DefaultMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistNoJournalSystem is
+// the journal-OFF counterpart of the restricted-whitelist system above, for the
+// TC-RG4 degraded-path ordering characterization (journal off ⇒ a reverted
+// commitment falls back to a plain FIFO-membership check and MAY be dropped).
+func DefaultMantleSingleChainMultiNodeWithTestSeqPreconfWhitelistNoJournalSystem(dest *DefaultMantleSingleChainMultiNodeWithTestSeqSystemIDs) stack.Option[*Orchestrator] {
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(WithGlobalL2ELOption(L2ELWithPreconf(
+		false, false,
+		[]string{PreconfWhitelistSenderAddr},
+		[]string{PreconfWhitelistRecipientAddr},
+		0,
+	)))
+	opt.Add(DefaultMantleSingleChainMultiNodeWithTestSeqSystem(dest))
+	return opt
+}
+
 func DefaultMantleSingleChainMultiNodeSystemWithoutP2P(dest *DefaultMantleSingleChainMultiNodeSystemIDs) stack.Option[*Orchestrator] {
 	ids := NewDefaultMantleSingleChainMultiNodeSystemIDs(DefaultL1ID, DefaultL2AID)
 

--- a/op-service/apis/test_sequencer.go
+++ b/op-service/apis/test_sequencer.go
@@ -39,6 +39,7 @@ type TestSequencerControlAPI interface {
 	Publish(ctx context.Context) error
 	Open(ctx context.Context) error
 	Seal(ctx context.Context) error
+	Cancel(ctx context.Context) error
 	Sign(ctx context.Context) error
 	Start(ctx context.Context, head common.Hash) error
 	Stop(ctx context.Context) (common.Hash, error)

--- a/op-service/sources/test_sequencer_control_client.go
+++ b/op-service/sources/test_sequencer_control_client.go
@@ -81,6 +81,10 @@ func (sc *ControlClient) Seal(ctx context.Context) error {
 	return sc.client.CallContext(ctx, nil, "sequencer_seal")
 }
 
+func (sc *ControlClient) Cancel(ctx context.Context) error {
+	return sc.client.CallContext(ctx, nil, "sequencer_cancel")
+}
+
 func (sc *ControlClient) Sign(ctx context.Context) error {
 	return sc.client.CallContext(ctx, nil, "sequencer_sign")
 }

--- a/op-test-sequencer/sequencer/backend/work/builders/fakepos/job.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/fakepos/job.go
@@ -139,7 +139,12 @@ func (j *Job) Open(ctx context.Context) error {
 		// wait for the block building to finish
 		time.Sleep(100 * time.Millisecond)
 
-		envelope, err = j.b.engine.GetPayloadV4(*res.PayloadID)
+		// The L1 in the Mantle devstack is at BPO2 (post-Osaka; see
+		// sysgo/mantle_system.go WithForkAtL1Genesis(forks.BPO2)), so the engine
+		// only serves getPayload via V5 — V4 returns "Unsupported fork". Osaka
+		// kept newPayloadV4, so only the getPayload call is bumped here (matching
+		// geth.EngineAPI, which exposes GetPayloadV5 but no NewPayloadV5).
+		envelope, err = j.b.engine.GetPayloadV5(*res.PayloadID)
 		if err != nil {
 			j.logger.Error("failed to finish building L1 block", "err", err)
 			return err

--- a/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/standardbuilder/builder.go
@@ -93,6 +93,12 @@ func (b *Builder) NewJob(ctx context.Context, opts seqtypes.BuildOpts) (work.Bui
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare payload attributes: %w", err)
 	}
+	// PreparePayloadAttributes hands back the verifier-mode template with
+	// NoTxPool=true (see op-node/rollup/derive/attributes.go). This builder
+	// drives the *sequencer*, so flip it to NoTxPool=false — otherwise the EL
+	// builds a deterministic derivation block (deposits only, no pool txs) and,
+	// on op-reth, the Mantle preconf pipeline is gated off entirely.
+	attrs.NoTxPool = false
 	b.log.Debug("Builder NewJob prepared payload attrs", "attrs", attrs)
 
 	id := seqtypes.RandomJobID()

--- a/op-test-sequencer/sequencer/backend/work/iface.go
+++ b/op-test-sequencer/sequencer/backend/work/iface.go
@@ -118,6 +118,15 @@ type Sequencer interface {
 	// Returns an error if there was no block-building job open.
 	Seal(ctx context.Context) error
 
+	// Cancel abandons the current in-flight build job without sealing or
+	// committing it. No getPayload / SealBlock is issued to the engine — the
+	// EL's in-flight payload is simply orphaned (superseded by the next
+	// OpenBlock, or garbage-collected), modeling a payload that is built and
+	// then dropped before it is ever committed. Sequencer state is reset so a
+	// fresh New can start (e.g. on the same parent with different attributes).
+	// Returns seqtypes.ErrUnknownJob if there is nothing to cancel.
+	Cancel(ctx context.Context) error
+
 	// Prebuilt inserts a pre-built block, skipping block-building.
 	Prebuilt(ctx context.Context, block Block) error
 

--- a/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/fullseq/sequencer.go
@@ -123,6 +123,23 @@ func (s *Sequencer) Seal(ctx context.Context) error {
 	return nil
 }
 
+// Cancel abandons the current in-flight build job without sealing or
+// committing it. No getPayload / SealBlock is issued to the engine — the EL's
+// in-flight payload is simply orphaned (superseded by the next OpenBlock, or
+// garbage-collected), modeling a payload that is built and then dropped before
+// it is ever committed. Sequencer state is reset so a fresh New can start (e.g.
+// on the same parent with different attributes).
+func (s *Sequencer) Cancel(ctx context.Context) error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.currentJob == nil && s.unsigned == nil {
+		return seqtypes.ErrUnknownJob
+	}
+	s.log.Debug("Sequencer Cancel request: abandoning in-flight build job without commit")
+	s.reset()
+	return nil
+}
+
 func (s *Sequencer) Prebuilt(ctx context.Context, block work.Block) error {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()

--- a/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/sequencer.go
+++ b/op-test-sequencer/sequencer/backend/work/sequencers/noopseq/sequencer.go
@@ -49,6 +49,10 @@ func (n *Sequencer) Seal(ctx context.Context) error {
 	return nil
 }
 
+func (n *Sequencer) Cancel(ctx context.Context) error {
+	return nil
+}
+
 func (n *Sequencer) Prebuilt(ctx context.Context, block work.Block) error {
 	return nil
 }

--- a/op-test-sequencer/sequencer/frontend/sequencer.go
+++ b/op-test-sequencer/sequencer/frontend/sequencer.go
@@ -39,6 +39,10 @@ func (bf *SequencerFrontend) Seal(ctx context.Context) error {
 	return toJsonError(bf.Sequencer.Seal(ctx))
 }
 
+func (bf *SequencerFrontend) Cancel(ctx context.Context) error {
+	return toJsonError(bf.Sequencer.Cancel(ctx))
+}
+
 func (bf *SequencerFrontend) PrebuiltEnvelope(ctx context.Context, block *eth.ExecutionPayloadEnvelope) error {
 	return toJsonError(bf.Sequencer.Prebuilt(ctx, block))
 }

--- a/op-test-sequencer/sequencer/frontend/sequencer_test.go
+++ b/op-test-sequencer/sequencer/frontend/sequencer_test.go
@@ -63,6 +63,11 @@ func (m *mockSequencer) Seal(ctx context.Context) error {
 	return m.err
 }
 
+func (m *mockSequencer) Cancel(ctx context.Context) error {
+	m.action = "cancel"
+	return m.err
+}
+
 func (m *mockSequencer) Prebuilt(ctx context.Context, block work.Block) error {
 	m.action = "prebuilt"
 	return m.err


### PR DESCRIPTION
Add preconf reorg integration tests under op-acceptance-tests/mantle-tests/preconf (reorg, reorg_nojournal, reorg_ordering, reorg_ordering_nojournal) and register them in acceptance-tests.yaml. Includes supporting changes to op-devstack presets/ sysgo and op-test-sequencer to drive the scenarios.